### PR TITLE
fix: distinguish zero buffer accesses

### DIFF
--- a/machine/architecture.js
+++ b/machine/architecture.js
@@ -22,6 +22,20 @@ export function contains(container, child) {
   )
 }
 
+export function bufferAccessSummary({ sharedHits, sharedReads }) {
+  const reach = sharedReads > 0 ? 'read' : sharedHits > 0 ? 'hit' : 'none'
+  const description = reach === 'read'
+    ? 'READ BELOW SHARED_BUFFERS'
+    : reach === 'hit'
+      ? 'ALL HIT IN SHARED_BUFFERS'
+      : 'NO SHARED-BUFFER ACCESSES REPORTED'
+  return {
+    reach,
+    text: `P MEASURED · HIT ${sharedHits} · READ ${sharedReads}`
+      + ` · ${description}`,
+  }
+}
+
 const STATEMENT_STAGE_SPECS = Object.freeze([
   Object.freeze({
     id: 'client',

--- a/machine/architecture.js
+++ b/machine/architecture.js
@@ -22,6 +22,14 @@ export function contains(container, child) {
   )
 }
 
+export const STATEMENT_EXECUTOR_RETURN_ROUTE = Object.freeze([
+  Object.freeze([600, 211]),
+  Object.freeze([600, 282]),
+  Object.freeze([215, 282]),
+  Object.freeze([215, 128]),
+  Object.freeze([124, 128]),
+])
+
 export function bufferAccessSummary({ sharedHits, sharedReads }) {
   const reach = sharedReads > 0 ? 'read' : sharedHits > 0 ? 'hit' : 'none'
   const description = reach === 'read'
@@ -185,13 +193,18 @@ export function createStatementReplay(report) {
   const writes = modifiesRows(plan)
   const sharedHits = finiteNumber(plan?.buffers?.sharedHits)
   const sharedReads = finiteNumber(plan?.buffers?.sharedReads)
+  const sharedCountsKnown = [plan?.buffers?.sharedHits, plan?.buffers?.sharedReads]
+    .every((value) => typeof value === 'number' && Number.isFinite(value) && value >= 0)
+  const noSharedAccess = sharedCountsKnown && sharedHits === 0 && sharedReads === 0
   const pacing = measuredPacing(plan)
   const rowMeasurement = resultMeasurement(report)
   const rows = rowMeasurement.count
   const stages = STATEMENT_STAGE_SPECS
     .filter((spec) => writes || (spec.id !== 'wal' && spec.id !== 'commit'))
     .map((spec) => {
-    const skipped = (spec.id === 'kernel' || spec.id === 'disk') && sharedReads === 0
+    const skipped = spec.id === 'buffer'
+      ? noSharedAccess
+      : (spec.id === 'kernel' || spec.id === 'disk') && sharedReads === 0
     let durationMs = spec.durationMs
     let measurement = null
     if (spec.id === 'plan') {
@@ -205,13 +218,17 @@ export function createStatementReplay(report) {
         ? `${finiteNumber(plan.executionTimeMs)} ms execution`
         : 'timing unavailable'
     } else if (spec.id === 'buffer') {
-      measurement = plan
-        ? `${sharedHits} hits · ${sharedReads} reads`
+      measurement = sharedCountsKnown
+        ? noSharedAccess
+          ? 'skipped · no shared-buffer accesses reported'
+          : `${sharedHits} hits · ${sharedReads} reads`
         : 'buffer counts unavailable'
     } else if (spec.id === 'kernel' || spec.id === 'disk') {
-      measurement = skipped
-        ? 'skipped · 0 shared reads'
-        : `${sharedReads} shared reads · route modelled`
+      measurement = !sharedCountsKnown
+        ? 'shared reads unavailable · route modelled'
+        : skipped
+          ? 'skipped · 0 shared reads'
+          : `${sharedReads} shared reads · route modelled`
     } else if (spec.id === 'wal') {
       measurement = 'WAL path modelled'
     } else if (spec.id === 'commit') {
@@ -221,6 +238,7 @@ export function createStatementReplay(report) {
     }
     return Object.freeze({
       ...spec,
+      source: spec.id === 'buffer' && !sharedCountsKnown ? 'model' : spec.source,
       durationMs,
       measurement,
       skipped,
@@ -255,6 +273,19 @@ export function nextStatementStageIndex(replay, currentIndex) {
     if (!replay.stages[index].skipped) return index
   }
   return replay.stages.length - 1
+}
+
+export function statementReturnRouteId(replay) {
+  if (replay?.writes) {
+    return replay.synchronousCommit === 'off' ? 'returnFromWal' : 'returnFromCommit'
+  }
+  const stages = replay?.stages
+  if (stages) {
+    for (let index = 0; index < stages.length; index += 1) {
+      if (stages[index].id === 'buffer' && stages[index].skipped) return 'returnFromExecutor'
+    }
+  }
+  return replay?.receipt?.sharedReads > 0 ? 'returnFromDisk' : 'returnFromBuffer'
 }
 
 export function activeStatementStageIndex(replay, elapsedMs) {

--- a/machine/architecture.test.js
+++ b/machine/architecture.test.js
@@ -3,10 +3,25 @@ import { describe, expect, it } from 'vitest'
 import {
   ARCHITECTURE_LAYOUT,
   activeStatementStageIndex,
+  bufferAccessSummary,
   contains,
   createStatementReplay,
   nextStatementStageIndex,
 } from './architecture.js'
+
+describe('Machine measured buffer access', () => {
+  it.each([
+    [0, 0, 'none', 'NO SHARED-BUFFER ACCESSES REPORTED'],
+    [1, 0, 'hit', 'ALL HIT IN SHARED_BUFFERS'],
+    [0, 1, 'read', 'READ BELOW SHARED_BUFFERS'],
+    [12, 3, 'read', 'READ BELOW SHARED_BUFFERS'],
+  ])('describes %i hits and %i reads', (sharedHits, sharedReads, reach, description) => {
+    expect(bufferAccessSummary({ sharedHits, sharedReads })).toEqual({
+      reach,
+      text: `P MEASURED · HIT ${sharedHits} · READ ${sharedReads} · ${description}`,
+    })
+  })
+})
 
 const REPORT = Object.freeze({
   source: 'postgres',

--- a/machine/architecture.test.js
+++ b/machine/architecture.test.js
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
   ARCHITECTURE_LAYOUT,
+  STATEMENT_EXECUTOR_RETURN_ROUTE,
   activeStatementStageIndex,
   bufferAccessSummary,
   contains,
   createStatementReplay,
   nextStatementStageIndex,
+  statementReturnRouteId,
 } from './architecture.js'
 
 describe('Machine measured buffer access', () => {
@@ -75,6 +77,66 @@ describe('Magnum PostgreSQL architecture containment', () => {
 })
 
 describe('Magnum statement replay', () => {
+  const resultOnly = () => createStatementReplay({
+    ...REPORT,
+    sql: 'SELECT 1;',
+    plan: {
+      ...REPORT.plan,
+      buffers: { source: 'postgres', sharedHits: 0, sharedReads: 0 },
+      root: { nodeType: 'Result', actualRows: 1, actualLoops: 1 },
+    },
+  })
+
+  it('skips unsupported shared-buffer access for a measured Result-only query', () => {
+    const replay = resultOnly()
+    expect(replay.stages.filter((stage) => stage.skipped).map((stage) => stage.id))
+      .toEqual(['buffer', 'kernel', 'disk'])
+    const executeIndex = replay.stages.findIndex((stage) => stage.id === 'execute')
+    expect(replay.stages[nextStatementStageIndex(replay, executeIndex)].id).toBe('return')
+    const throughExecution = replay.stages.slice(0, executeIndex + 1)
+      .reduce((sum, stage) => sum + stage.durationMs, 0)
+    expect(replay.stages[activeStatementStageIndex(replay, throughExecution)].id).toBe('return')
+  })
+
+  it('returns a measured no-shared-access result directly from the executor', () => {
+    expect(statementReturnRouteId(resultOnly())).toBe('returnFromExecutor')
+    expect(STATEMENT_EXECUTOR_RETURN_ROUTE[0]).toEqual([600, 211])
+    expect(STATEMENT_EXECUTOR_RETURN_ROUTE.at(-1)).toEqual([124, 128])
+    expect(Math.max(...STATEMENT_EXECUTOR_RETURN_ROUTE.map((point) => point[1])))
+      .toBeLessThan(ARCHITECTURE_LAYOUT.sharedMemory.y)
+  })
+
+  it.each([[1, 0, 'returnFromBuffer'], [0, 1, 'returnFromDisk'], [12, 3, 'returnFromDisk']])(
+    'preserves the measured route for %i hits and %i reads', (sharedHits, sharedReads, route) => {
+      const replay = createStatementReplay({
+        ...REPORT,
+        plan: { ...REPORT.plan, buffers: { sharedHits, sharedReads }, root: { nodeType: 'Result' } },
+      })
+      expect(replay.stages.find((stage) => stage.id === 'buffer').skipped).toBe(false)
+      expect(statementReturnRouteId(replay)).toBe(route)
+    },
+  )
+
+  it.each([null, {}, { sharedHits: 0 }, { sharedHits: 0, sharedReads: NaN }])(
+    'does not treat unavailable counters as measured zero: %j', (buffers) => {
+      const replay = createStatementReplay({ ...REPORT, plan: { ...REPORT.plan, buffers } })
+      const stage = replay.stages.find((stage) => stage.id === 'buffer')
+      expect(stage.skipped).toBe(false)
+      expect(stage.source).toBe('model')
+      expect(stage.measurement).toBe('buffer counts unavailable')
+      expect(statementReturnRouteId(replay)).toBe('returnFromBuffer')
+    },
+  )
+
+  it.each(['on', 'off'])('preserves the modelled write return path with synchronous_commit=%s', (setting) => {
+    const replay = createStatementReplay({
+      ...REPORT,
+      plan: { ...REPORT.plan, root: { nodeType: 'ModifyTable', operation: 'Update' } },
+    })
+    expect(statementReturnRouteId({ ...replay, synchronousCommit: setting }))
+      .toBe(setting === 'off' ? 'returnFromWal' : 'returnFromCommit')
+  })
+
   it('turns the submitted SQL and its EXPLAIN report into one ordered trip', () => {
     const replay = createStatementReplay(REPORT)
 

--- a/machine/magnum.js
+++ b/machine/magnum.js
@@ -1,6 +1,7 @@
 import {
   ARCHITECTURE_LAYOUT as layout,
   activeStatementStageIndex,
+  bufferAccessSummary,
   createStatementReplay,
   nextStatementStageIndex,
 } from './architecture.js'
@@ -3007,12 +3008,9 @@ function updatePostgresUi() {
   if (statement.status === 'measuring') {
     measurementLabel.textContent = 'P MEASURING EXPLAIN (ANALYZE, BUFFERS)…'
   } else if (postgres.plan) {
-    const buffers = postgres.plan.buffers
-    const hasRead = buffers.sharedReads > 0
-    postgresMeasurement.dataset.reach = hasRead ? 'read' : 'hit'
-    measurementLabel.textContent =
-      `P MEASURED · HIT ${buffers.sharedHits} · READ ${buffers.sharedReads}`
-      + ` · ${hasRead ? 'READ BELOW SHARED_BUFFERS' : 'ALL HIT IN SHARED_BUFFERS'}`
+    const access = bufferAccessSummary(postgres.plan.buffers)
+    postgresMeasurement.dataset.reach = access.reach
+    measurementLabel.textContent = access.text
   } else if (postgres.report) {
     measurementLabel.textContent = postgres.report.error
       ? 'P ERROR · QUERY ARM IDLE'
@@ -3583,9 +3581,7 @@ window.MAGNUM = Object.freeze({
           ? 'model'
           : postgres.plan === null
             ? 'idle'
-            : postgres.plan.buffers.sharedReads > 0
-              ? 'read'
-              : 'hit',
+            : bufferAccessSummary(postgres.plan.buffers).reach,
       timing: postgres.timing,
       error: postgres.report?.error ?? postgres.initError,
     },

--- a/machine/magnum.js
+++ b/machine/magnum.js
@@ -1,9 +1,11 @@
 import {
   ARCHITECTURE_LAYOUT as layout,
+  STATEMENT_EXECUTOR_RETURN_ROUTE,
   activeStatementStageIndex,
   bufferAccessSummary,
   createStatementReplay,
   nextStatementStageIndex,
+  statementReturnRouteId,
 } from './architecture.js'
 import {
   formatDescribeIndex,
@@ -333,6 +335,7 @@ const backendSpecs = Object.freeze([
 ])
 
 const statementRoutes = Object.freeze({
+  returnFromExecutor: STATEMENT_EXECUTOR_RETURN_ROUTE,
   backend: Object.freeze([
     Object.freeze([124, 128]),
     Object.freeze([215, 128]),
@@ -2364,14 +2367,7 @@ function statementRouteForStage(stageId) {
     return statementRoutes.earlyAck
   }
   if (stageId === 'return') {
-    if (statement.replay?.writes) {
-      return statement.replay.synchronousCommit === 'off'
-        ? statementRoutes.returnFromWal
-        : statementRoutes.returnFromCommit
-    }
-    return statement.replay?.receipt?.sharedReads > 0
-      ? statementRoutes.returnFromDisk
-      : statementRoutes.returnFromBuffer
+    return statementRoutes[statementReturnRouteId(statement.replay)]
   }
   return statementRoutes[stageId] ?? null
 }


### PR DESCRIPTION
## Summary
- Distinguish measured shared-buffer reads, hits, and zero reported accesses.
- For `select 1` with zero hits and reads, say “NO SHARED-BUFFER ACCESSES REPORTED” instead of implying a cache hit.
- Use the same classification in the visible Machine report and debug reach.

Closes #13. Part of #10 / Sprint 1.

## Verification
- Red/green regression: reproduced the prior zero-access misclassification, then corrected it.
- Focused Machine tests, typecheck, and production build passed.
- Initial full local run: 1,060 tests passed, three unchanged simulation tests timed out under concurrent browser CPU load, one skipped. The unchanged root-cause tests subsequently passed in isolation.
- Actual PGlite `select 1` browser verification is being completed by the integration QA agent; evidence will be added before merge.
- CI and substantive REV review are required before merge.

## Scope and risk
Presentation interpretation only; no changes to PostgreSQL execution or the simulation. Zero buffer accesses do not imply that all work occurred in shared_buffers.