### PR TITLE
feat: refine city composition and labels

### DIFF
--- a/src/engine/camera-controls.test.ts
+++ b/src/engine/camera-controls.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createBus } from '../core/bus'
 import type { Bus } from '../core/types'
 import { installTestDom } from '../../test/dom'
-import { CITY } from '../world/layout'
+import { ANCHOR, CITY } from '../world/layout'
 import { createCameraRig, type CameraRig } from './camera'
 
 vi.mock('../world/slonik', () => ({
@@ -354,6 +354,25 @@ describe('map camera mouse controls', () => {
   afterEach(() => {
     fixture.rig.dispose()
   })
+
+  it.each([[1280, 760], [1440, 900], [390, 844]])(
+    'keeps the client-to-memory landmarks inside the opening frame at %s × %s',
+    (width, height) => {
+      fixture.camera.fov = 52
+      fixture.rig.resize(width, height)
+      fixture.rig.home(true)
+      fixture.camera.updateMatrixWorld()
+      for (const anchor of [ANCHOR.clientTerminal, ANCHOR.postmasterTop, ANCHOR.plaza]) {
+        const projected = new THREE.Vector3(...anchor).project(fixture.camera)
+        const x = (projected.x + 1) * 0.5
+        const y = (1 - projected.y) * 0.5
+        expect(x, `landmark ${anchor} must clear the horizontal edge`).toBeGreaterThan(0.08)
+        expect(x).toBeLessThan(0.92)
+        expect(y, `landmark ${anchor} must clear the top instruments`).toBeGreaterThan(0.18)
+        expect(y, `landmark ${anchor} must clear the transport dock`).toBeLessThan(0.87)
+      }
+    },
+  )
 
   it('plain left-drag pans without rotating', () => {
     const pivotBefore = fixture.rig.pivot.clone()
@@ -915,7 +934,10 @@ describe('map camera mouse controls', () => {
     fixture.rig.update(1 / 60)
 
     expect(fixture.rig.pivot.distanceTo(pivotBefore)).toBeGreaterThan(0.1)
-    expect(fixture.camera.quaternion.angleTo(rotationBefore)).toBeLessThan(1e-8)
+    /* acos(dot) amplifies roundoff near an unchanged orientation. */
+    for (const axis of ['x', 'y', 'z', 'w'] as const) {
+      expect(fixture.camera.quaternion[axis]).toBeCloseTo(rotationBefore[axis], 12)
+    }
   })
 
   it('does not coast after a reduced-motion rotate drag is released', () => {

--- a/src/engine/camera.ts
+++ b/src/engine/camera.ts
@@ -109,16 +109,11 @@ const FOCUS_UP_BIAS = 0.436 // 25°
 /** Fraction of a tour path spent easing in / out. */
 const PATH_EASE = 0.18
 
-/**
- * The establishing shot. From the north-west, high enough that the whole
- * surface reads at once: maintenance yard (west) on the right of frame, WAL
- * district (east) on the left, backend row across the middle, plaza dead
- * centre, and the excavation opening below it. Aim point is pulled slightly
- * west of the origin so the landfill and the archive store sit symmetrically
- * inside the horizontal FOV.
- */
-const HOME_POS = new THREE.Vector3(-218, 216, -342)
-const HOME_PIVOT = new THREE.Vector3(-18, 0, -16)
+/* A raised three-quarter view keeps the client terminal in the foreground,
+ * the backend row clear of the basin, and storage visible below the deck.
+ * The complete Slonik silhouette belongs to the separate plan preset. */
+const HOME_POS = new THREE.Vector3(-250, 285, -365)
+const HOME_PIVOT = new THREE.Vector3(-5, -6, -45)
 
 /**
  * THE OVERVIEW SHOT — straight down on the plate.

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -36,7 +36,7 @@
     'brand controls'
     'vitals vitals';
   align-items: center;
-  gap: 0 12px;
+  gap: 0 10px;
   min-height: 54px;
   padding: 4px 12px;
   border-radius: 0;
@@ -141,7 +141,7 @@
      divided a 176px strip between them on a phone and every readout was
      squeezed to a 16px sliver of itself. */
   flex: 0 0 auto;
-  padding: 7px 14px;
+  padding: 4px 12px;
   display: grid;
   /* Fixed columns: a metric tile must never resize as its number changes, or
      every tile to its right dances. Value column is sized for the longest
@@ -1041,8 +1041,8 @@ body.pg-trace .hud-transport > .hud-sep {
 }
 .hud-compass__canvas {
   display: block;
-  width: 196px;
-  height: 168px;
+  width: 160px;
+  height: 137px;
   cursor: crosshair;
   border-radius: 0;
 }
@@ -1314,11 +1314,36 @@ body.pg-walk.touch-walk-active .hud-walk {
    and 1280x800 is the most common laptop there is. */
 @media (max-width: 1440px) {
   .hud-vital {
-    padding: 7px 11px;
+    padding: 4px 10px;
     grid-template-columns: auto;
   }
   .hud-vital .pg-spark {
     display: none;
+  }
+}
+
+/* At laptop widths the compact vitals fit beside the identity. Controls keep
+   their complete second row, freeing a full row of the opening city view. */
+@media (min-width: 1081px) and (max-width: 1440px) {
+  .hud-bar.is-stacked {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+      'brand vitals'
+      'controls controls';
+    row-gap: 0;
+  }
+  .hud-bar.is-stacked .hud-vitals {
+    justify-self: end;
+  }
+  .hud-bar.is-stacked .hud-right {
+    justify-self: stretch;
+    justify-content: space-between;
+    border-top: 1px solid var(--line-hair);
+  }
+  .hud-bar.is-stacked .hud-tools {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 4px;
   }
 }
 

--- a/src/styles/labels.css
+++ b/src/styles/labels.css
@@ -65,11 +65,11 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  column-gap: 14px;
-  padding: 5px 10px 5px 9px;
-  border: 0;
-  border-radius: 0;
-  background: rgba(8, 13, 24, 0.9);
+  column-gap: 10px;
+  padding: 6px 10px;
+  border: 1px solid var(--line-hair);
+  border-radius: 3px;
+  background: var(--bg-panel);
   white-space: normal;
   pointer-events: auto;
   cursor: pointer;
@@ -91,8 +91,8 @@
   font-size: var(--fs-xs);
   font-style: normal;
   font-weight: 600;
-  letter-spacing: 0.13em;
-  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  text-transform: none;
   color: var(--ink);
   white-space: nowrap;
 }
@@ -202,7 +202,7 @@
 
 .lbl__chip:hover,
 .lbl.is-hovered .lbl__chip {
-  background: rgba(12, 20, 34, 0.96);
+  background: var(--bg-panel-solid);
 }
 
 .lbl.is-hovered .lbl__leader {
@@ -246,8 +246,8 @@
 }
 
 .lbl.is-name-only .lbl__chip {
-  padding: 3px 8px 3px 8px;
-  background: rgba(8, 13, 24, 0.84);
+  padding: 4px 8px;
+  background: var(--bg-panel);
 }
 
 /* collapse to the tracks that still carry something, otherwise the (now empty)
@@ -263,7 +263,7 @@
 }
 
 .lbl.is-name-only .lbl__name {
-  font-size: var(--fs-micro);
+  font-size: var(--fs-xs);
   color: var(--ink-dim);
 }
 
@@ -279,7 +279,7 @@
   grid-template-columns: minmax(0, 1fr);
   column-gap: 0;
   padding: 4px 9px 4px 8px;
-  background: rgba(6, 11, 20, 0.9);
+  background: var(--bg-panel);
 }
 
 .lbl--district.has-more .lbl__chip {
@@ -291,7 +291,7 @@
 .lbl--district .lbl__name {
   font-size: var(--fs-xs);
   font-weight: 600;
-  letter-spacing: 0.22em;
+  letter-spacing: 0.08em;
   color: var(--ink);
 }
 
@@ -312,12 +312,12 @@
   grid-template-columns: minmax(0, 1fr);
   column-gap: 0;
   padding: 5px 13px 5px 12px;
-  background: rgba(6, 11, 20, 0.88);
+  background: var(--bg-panel);
 }
 
 .lbl--city .lbl__name {
   font-size: var(--fs-sm);
-  letter-spacing: 0.3em;
+  letter-spacing: 0.16em;
   color: var(--ink);
 }
 

--- a/src/world/ground-surface.test.ts
+++ b/src/world/ground-surface.test.ts
@@ -8,9 +8,26 @@ import {
   GROUND_SURFACE_WORLD_METRES,
   createGroundSurfaceData,
   groundSurfaceDetail,
+  groundSurveyDetail,
 } from './ground-surface'
 
 describe('procedural ground surface', () => {
+  it('reveals survey detail near the street and retires it continuously at city altitude', () => {
+    expect(groundSurveyDetail(0)).toBe(1)
+    expect(groundSurveyDetail(40)).toBe(1)
+    expect(groundSurveyDetail(320)).toBe(0)
+    expect(groundSurveyDetail(1650)).toBe(0)
+    let previous = 1
+    for (let height = 0; height <= 400; height += 5) {
+      const detail = groundSurveyDetail(height)
+      expect(detail).toBeGreaterThanOrEqual(0)
+      expect(detail).toBeLessThanOrEqual(previous)
+      expect(previous - detail).toBeLessThan(0.03)
+      expect(groundSurveyDetail(-height)).toBe(detail)
+      previous = detail
+    }
+  })
+
   it('builds one deterministic, materially varied tile without an image asset', () => {
     const a = createGroundSurfaceData()
     const b = createGroundSurfaceData()

--- a/src/world/ground-surface.ts
+++ b/src/world/ground-surface.ts
@@ -14,6 +14,12 @@ export const GROUND_SURFACE_MAX_SLOPE = 0.12
 const ROUGHNESS_MIN = 0.72
 const ROUGHNESS_MAX = 0.94
 
+/** Street-scale survey marks retire smoothly as the camera rises above them. */
+export function groundSurveyDetail(cameraHeight: number): number {
+  const t = Math.max(0, Math.min(1, (Math.abs(cameraHeight) - 40) / 280))
+  return 1 - t * t * (3 - 2 * t)
+}
+
 /**
  * Tileable aggregate and curing variation for the civic paving. The original
  * height is retained in B while RG and A derive its normal and roughness.

--- a/src/world/ground.ts
+++ b/src/world/ground.ts
@@ -9,6 +9,7 @@ import {
   GROUND_SURFACE_SIZE,
   createGroundSurfaceData,
   groundSurfaceDetail,
+  groundSurveyDetail,
 } from './ground-surface'
 import {
   clearance,
@@ -86,6 +87,7 @@ uniform float uSweepR;
 uniform sampler2D uSurface;
 uniform float uSurfaceDetail;
 uniform float uSurfaceResponse;
+uniform float uSurveyDetail;
 uniform vec3 uSunDirection;
 uniform vec3 uSunColor;
 uniform sampler2D uEdge;
@@ -117,17 +119,19 @@ void main() {
   float edge = ( texture2D( uEdge, euv ).r - 0.5 ) * 2.0 * uEdgeMax;
 
   float dMinor, dMajor;
-  float minor = gridMask( p, 10.0, 1.15, dMinor );   // 10 m survey grid
-  float major = gridMask( p, 50.0, 1.70, dMajor );   // 50 m block grid
+  float minor = gridMask( p, 10.0, 0.85, dMinor );   // 10 m survey grid
+  float major = gridMask( p, 50.0, 1.15, dMajor );   // 50 m block grid
 
   minor *= 1.0 - smoothstep( 0.20, 0.80, dMinor );
   major *= 1.0 - smoothstep( 0.28, 1.05, dMajor );
 
-  // Survives the overview shot: the camera sits 1.3 km up there and the survey
-  // grid is most of what makes the plate read as a poured surface at all.
-  float camFade = 1.0 - smoothstep( 950.0, 2700.0, distance( vWorld, cameraPosition ) );
-  minor *= camFade;
-  major *= camFade;
+  // Close paving supplies scale; the distant city keeps only a quiet block
+  // rhythm. Per-fragment distance also retires the horizon in walking views.
+  float viewDistance = distance( vWorld, cameraPosition );
+  minor *= ( 1.0 - smoothstep( 180.0, 720.0, viewDistance ) )
+         * mix( 0.12, 0.60, uSurveyDetail );
+  major *= ( 1.0 - smoothstep( 700.0, 2200.0, viewDistance ) )
+         * mix( 0.40, 0.72, uSurveyDetail );
 
   // The survey grid stops at the plate, not in the fog: it dies in the last
   // 34 m so the kerb is a boundary and not just the place the lines get cut.
@@ -152,7 +156,8 @@ void main() {
     vec2 panelP = vec2( p.x + mod( row, 2.0 ) * 2.1, p.y * ( 4.2 / 3.1 ) );
     float dPanel;
     float panel = gridMask( panelP, 4.2, 1.18, dPanel );
-    panel *= 1.0 - smoothstep( 0.16, 0.58, dPanel );
+    panel *= ( 1.0 - smoothstep( 0.16, 0.58, dPanel ) )
+           * mix( 0.24, 1.0, uSurveyDetail );
     col *= 1.0 - panel * 0.115;
   }
   if ( uSurfaceDetail > 1.5 ) {
@@ -537,6 +542,7 @@ export const createGround: WorldFactory = (ctx: WorldContext): WorldModule => {
       uSurface: { value: surfaceTex },
       uSurfaceDetail: { value: 0 },
       uSurfaceResponse: { value: 0 },
+      uSurveyDetail: { value: groundSurveyDetail(ctx.camera.position.y) },
       uSunDirection: {
         value: new THREE.Vector3(...ATMOSPHERE.day.keyPos)
           .sub(new THREE.Vector3(...ATMOSPHERE.day.keyTarget))
@@ -559,6 +565,7 @@ export const createGround: WorldFactory = (ctx: WorldContext): WorldModule => {
   const uTime = gridUniforms.uTime as { value: number }
   const uSurfaceDetail = gridUniforms.uSurfaceDetail as { value: number }
   const uSurfaceResponse = gridUniforms.uSurfaceResponse as { value: number }
+  const uSurveyDetail = gridUniforms.uSurveyDetail as { value: number }
 
   const plateMat = new THREE.ShaderMaterial({
     uniforms: gridUniforms,
@@ -1195,6 +1202,7 @@ export const createGround: WorldFactory = (ctx: WorldContext): WorldModule => {
 
   function update(dt: number, _sim: SimState, _t: number): void {
     syncConeLayer()
+    uSurveyDetail.value = groundSurveyDetail(ctx.camera.position.y)
     const daylight = atmosphere().daylight
     const nextSurfaceDetail = groundSurfaceDetail(daylight ? 'day' : 'night', quality.level)
     if (nextSurfaceDetail !== surfaceDetail) {

--- a/test/labels-text.test.ts
+++ b/test/labels-text.test.ts
@@ -10,15 +10,65 @@ import {
 } from '../src/engine/label-detail'
 
 const css = readFileSync(fileURLToPath(new URL('../src/styles/labels.css', import.meta.url)), 'utf8')
+const tokens = readFileSync(fileURLToPath(new URL('../src/styles/tokens.css', import.meta.url)), 'utf8')
 
-function rule(selector: string): string {
+function rule(selector: string, source = css): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]+)\\}`))
+  const match = source.match(new RegExp(`${escaped}\\s*\\{([^}]+)\\}`))
   expect(match, `missing ${selector} rule`).not.toBeNull()
   return match?.[1] ?? ''
 }
 
+function token(name: string, day: boolean): string {
+  const root = day ? ':root[data-theme="day"]' : ':root'
+  const start = tokens.indexOf(`${root} {`)
+  const body = tokens.slice(start, tokens.indexOf('}', start))
+  const value = body.match(new RegExp(`${name}:\\s*([^;]+)`))?.[1]
+  if (!value) throw new Error(`missing ${name} in ${root}`)
+  return value
+}
+
+function color(value: string, day: boolean): number[] {
+  if (value.startsWith('var(')) return color(token(value.slice(4, -1), day), day)
+  if (value.startsWith('#')) {
+    return [1, 3, 5].map((offset) => parseInt(value.slice(offset, offset + 2), 16)).concat(1)
+  }
+  const channels = value.match(/[\d.]+/g)?.map(Number)
+  if (!channels || channels.length < 3) throw new Error(`unsupported color ${value}`)
+  return channels.length === 3 ? [...channels, 1] : channels
+}
+
+function luminance(rgb: number[]): number {
+  return rgb.slice(0, 3).reduce((sum, value, index) => {
+    const srgb = value / 255
+    const linear = srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4
+    return sum + linear * [0.2126, 0.7152, 0.0722][index]
+  }, 0)
+}
+
 describe('floating label text', () => {
+  it.each([false, true])('keeps name-only text legible over bright and dark scenery (day=%s)', (day) => {
+    /* Name-only and the day override have equal specificity; labels.css is
+     * loaded later, so its own background wins when it supplies one. */
+    const defaultSurface = day
+      ? rule(':root[data-theme="day"] .lbl__chip', tokens)
+      : rule('.lbl__chip')
+    const background = rule('.lbl.is-name-only .lbl__chip').match(/background:\s*([^;]+)/)?.[1]
+      ?? defaultSurface.match(/background:\s*([^;]+)/)![1]
+    const foreground = rule('.lbl.is-name-only .lbl__name').match(/color:\s*([^;]+)/)![1]
+    const fg = luminance(color(foreground, day))
+    const surface = color(background, day)
+    for (const scenery of [0, 255]) {
+      const composited = surface.slice(0, 3).map(
+        (channel) => channel * surface[3] + scenery * (1 - surface[3]),
+      )
+      const bg = luminance(composited)
+      const contrast = (Math.max(fg, bg) + 0.05) / (Math.min(fg, bg) + 0.05)
+      expect(contrast, `name-only label over ${scenery === 0 ? 'black' : 'white'} scenery`)
+        .toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
   it.each(['.lbl__name', '.lbl__role', '.lbl__read'])(
     'does not clip or ellipsize %s',
     (selector) => {


### PR DESCRIPTION
## Summary
- Reframe the opening camera around recognizable city landmarks.
- Reduce ground-grid visual noise with distance and altitude.
- Correct day-mode label contrast and compact laptop HUD layout without removing technical qualifications.

Closes #11. Part of #10 / Sprint 1.

## Verification
80 focused tests, typecheck and production build passed on the feature branch. The label defect was reproduced at 2.66:1 contrast, then corrected to at least 4.5:1. Initial combined desktop browser images were inspected; night/mobile/tablet acceptance remains an explicit QA gate. CI and substantive REV review are required before merge.

## Scope
No simulation or district topology changes. This is composition and legibility groundwork, not a claim that the premium graphics redesign is finished.