### PR TITLE
feat: enrich materials and stable lighting

### DIFF
--- a/src/core/beveled-box.test.ts
+++ b/src/core/beveled-box.test.ts
@@ -36,9 +36,36 @@ describe('build-time box bevels', () => {
   it('keeps the rescue tiers on twelve-triangle boxes', () => {
     expect(boxBevelDetail('low')).toBe(0)
     expect(boxBevelDetail('reduced')).toBe(0)
-    expect(boxBevelDetail('medium')).toBe(0)
+    expect(boxBevelDetail('medium')).toBe(1)
     expect(boxBevelDetail('high')).toBe(1)
     expect(boxBevelDetail('ultra')).toBe(1)
+  })
+
+  it('keeps medium architectural bevels without multiplying dense field geometry', () => {
+    const pair = pairBoxGeometries(1, 1, 1)
+    const city = new THREE.Group()
+    const buildings = new THREE.InstancedMesh(pair.plain, new THREE.MeshStandardMaterial(), 32)
+    const field = new THREE.InstancedMesh(pair.plain, new THREE.MeshBasicMaterial(), 1024)
+    city.add(buildings, field)
+
+    applyBoxBevelDetail(city, 'high')
+    expect(field.geometry).toBe(pair.beveled)
+    const medium = applyBoxBevelDetail(city, 'medium')
+    expect(buildings.geometry).toBe(pair.beveled)
+    expect(field.geometry).toBe(pair.plain)
+    expect(medium.triangleDelta).toBe(32 * (44 - 12))
+    expect(medium.triangles).toBe(32 * 44 + 1024 * 12)
+
+    applyBoxBevelDetail(city, 'reduced')
+    expect(buildings.geometry).toBe(pair.plain)
+    applyBoxBevelDetail(city, 'medium')
+    expect(buildings.geometry).toBe(pair.beveled)
+    expect(field.geometry).toBe(pair.plain)
+
+    field.count = 8
+    applyBoxBevelDetail(city, 'high')
+    applyBoxBevelDetail(city, 'medium')
+    expect(field.geometry === pair.plain).toBe(true)
   })
 
   it('swaps paired city boxes without touching unpaired semantic tiles', () => {

--- a/src/core/beveled-box.ts
+++ b/src/core/beveled-box.ts
@@ -25,7 +25,7 @@ export interface BoxBevelStats {
 }
 
 export function boxBevelDetail(level: QualityLevel): 0 | 1 {
-  return level === 'high' || level === 'ultra' ? 1 : 0
+  return level === 'medium' || level === 'high' || level === 'ultra' ? 1 : 0
 }
 
 function pushFace(
@@ -193,7 +193,7 @@ export function pairBoxGeometries(
 
 /** Swap geometry only when quality changes; the frame loop never touches it. */
 export function applyBoxBevelDetail(root: THREE.Object3D, level: QualityLevel): BoxBevelStats {
-  const detailed = boxBevelDetail(level) === 1
+  const enabled = boxBevelDetail(level) === 1
   let boxes = 0
   let triangles = 0
   let triangleDelta = 0
@@ -203,10 +203,16 @@ export function applyBoxBevelDetail(root: THREE.Object3D, level: QualityLevel): 
     if (mesh.isMesh !== true) return
     const pair = (mesh.geometry.userData as BoxGeometryData).pgBoxPair
     if (!pair) return
-    mesh.geometry = detailed ? pair.beveled : pair.plain
     const count = (mesh as THREE.InstancedMesh).isInstancedMesh === true
       ? (mesh as THREE.InstancedMesh).count
       : 1
+    const capacity = (mesh as THREE.InstancedMesh).isInstancedMesh === true
+      ? (mesh as THREE.InstancedMesh).instanceMatrix.count
+      : 1
+    /* Medium retains architectural edges but does not multiply geometry in
+     * the page grids and other large state fields. */
+    const detailed = enabled && (level !== 'medium' || capacity <= 128)
+    mesh.geometry = detailed ? pair.beveled : pair.plain
     boxes += count
     triangles += (detailed ? BEVELED_BOX_TRIANGLES : BOX_TRIANGLES) * count
     triangleDelta += (detailed ? BEVELED_BOX_TRIANGLES - BOX_TRIANGLES : 0) * count

--- a/src/core/theme.test.ts
+++ b/src/core/theme.test.ts
@@ -5,6 +5,7 @@ import {
   COLOR,
   atmosphere,
   createTheme,
+  paintSceneMaterial,
   setBloomAvailable,
   setThemeClockMinutes,
   setThemeMode,
@@ -282,8 +283,8 @@ describe('the masonry surface term', () => {
       compile(theme.mat('wal.glass', { color: 0x9fd8ff, surface: false }), true),
     )
     expect(out.fragmentShader).not.toContain('pgWorld')
-    // ...but that material still gets the day toon ramp, which is not optional.
-    expect(out.fragmentShader).toContain('RE_Direct_Toon')
+    // Daylight still shades surfaces that opt out of the masonry detail.
+    expect(out.fragmentShader).toContain('RE_Direct_Daylight')
   })
 
   it('derives roughness and a restrained normal from the same surface height', () => {
@@ -337,7 +338,7 @@ describe('the masonry surface term', () => {
   })
 })
 
-describe('the day toon ramp', () => {
+describe('the daylight material response', () => {
   let theme: ReturnType<typeof createTheme>
 
   beforeEach(() => {
@@ -352,25 +353,76 @@ describe('the day toon ramp', () => {
 
   it('is compiled in for daylight and left out at night', () => {
     const day = inMode('day', () => compile(theme.mat('maint.struct', { color: 0x2b3550 }), true))
-    expect(day.fragmentShader).toContain('#define RE_Direct RE_Direct_Toon')
+    expect(day.fragmentShader).toContain('#define RE_Direct RE_Direct_Daylight')
 
     const night = inMode('night', () => compile(theme.mat('maint.heavy', { color: 0x232d44 }), true))
-    expect(night.fragmentShader).not.toContain('RE_Direct_Toon')
+    expect(night.fragmentShader).not.toContain('RE_Direct_Daylight')
   })
 
-  it('separates a roof from a sunlit wall', () => {
+  it('retains the authored distinction between metal and matte masonry', () => {
+    const stone = theme.mat('storage.stone', { color: 0x27334c, roughness: 0.72, metalness: 0.15 })
+    const metal = theme.mat('storage.steel', { color: 0x27334c, roughness: 0.24, metalness: 0.85 })
+    setThemeMode('day', { persist: false })
+
+    expect(metal.metalness).toBeGreaterThanOrEqual(0.8)
+    expect(metal.roughness).toBeLessThanOrEqual(0.3)
+    expect(stone.roughness - metal.roughness).toBeGreaterThan(0.4)
+    expect(stone.metalness).toBeLessThan(0.1)
+
+    setThemeMode('night', { persist: false })
+    expect(metal.metalness).toBe(0.85)
+    expect(metal.roughness).toBe(0.24)
+    expect(stone.metalness).toBe(0.15)
+    expect(stone.roughness).toBe(0.72)
+  })
+
+  it('paints cached and independently authored metals consistently', () => {
+    const spec = { color: 0x27334c, roughness: 0.24, metalness: 0.85 }
+    const cached = theme.mat('storage.steel', spec)
+    const independent = new THREE.MeshStandardMaterial(spec)
+    independent.name = 'storage.steel'
+    paintSceneMaterial(independent, 'night')
+    setThemeMode('day', { persist: false })
+    paintSceneMaterial(independent, 'day')
+
+    expect(independent.roughness).toBe(cached.roughness)
+    expect(independent.metalness).toBe(cached.metalness)
+    expect(independent.userData.pgSurface).toBe(false)
+
+    paintSceneMaterial(independent, 'night')
+    expect(independent.roughness).toBe(spec.roughness)
+    expect(independent.metalness).toBe(spec.metalness)
+    independent.dispose()
+  })
+
+  it('models continuous daylight and a restrained roof lift', () => {
     const out = inMode('day', () => compile(theme.mat('rep.struct', { color: 0x27334c }), true))
-    /* Three ingredients, all required: two N·L thresholds for the wall tones,
-     * and a world-space up term for the roof, which no dot product against the
-     * sun can find on its own — a roof and a wall can share a dot product. */
-    expect(out.fragmentShader).toContain('0.14 - w')
-    expect(out.fragmentShader).toContain('0.68 - w')
+    /* Execute the shipped scalar GLSL, rather than a separately maintained
+     * CPU approximation. These operations have the same scalar semantics. */
+    const body = /float pgDayDiffuse\( float dotNL, float up \) \{([^}]+)\}/.exec(out.fragmentShader)?.[1]
+    expect(body).toBeDefined()
+    const response = new Function('dotNL', 'up', `const sqrt = Math.sqrt; ${body!.replace(/\bfloat\b/g, 'const')}`) as (facing: number, up: number) => number
+
+    expect(response(0, 0)).toBe(0)
+    expect(response(1, 0)).toBeGreaterThan(0.75)
+    expect(response(1, 1)).toBeLessThanOrEqual(1)
+    for (let i = 1; i <= 100; i++) {
+      const facing = i / 100
+      const wall = response(facing, 0)
+      const roof = response(facing, 1)
+      expect(wall).toBeGreaterThan(response(facing - 0.01, 0))
+      expect(wall - response(facing - 0.01, 0)).toBeLessThan(0.05)
+      expect(roof).toBeGreaterThan(wall)
+      expect(roof - wall).toBeLessThan(0.15)
+    }
     expect(out.fragmentShader).toContain('worldN.y')
   })
 
-  it('gates the cartoon highlight on roughness so matte stone stays matte', () => {
+  it('retains a smooth physical highlight while keeping stone matte', () => {
     const out = inMode('day', () => compile(theme.mat('shmem.struct', { color: 0x1b2435 }), true))
-    expect(out.fragmentShader).toContain('smoothstep( 0.35, 0.75, material.roughness )')
+    expect(out.fragmentShader).toContain('BRDF_GGX_Multiscatter')
+    expect(out.fragmentShader).toContain('smoothstep( 0.35, 0.85, material.roughness )')
+    expect(out.fragmentShader).not.toContain('specLum')
   })
 
   it('leaves the night vertex-colour buffers alone', () => {

--- a/src/core/theme.ts
+++ b/src/core/theme.ts
@@ -43,7 +43,7 @@ export { ATMOSPHERE, DAY_PALETTE, NIGHT_PALETTE, PALETTES } from './themes'
  * meaning — data, state, energy — with `neon()`.
  *
  * DAY: the same call sites, a different rendering model. `mat()` becomes light
- * pale stone under a stepped toon ramp lit by a low warm sun; `neon()` becomes a
+ * stone and reflective machinery lit by a low warm sun; `neon()` becomes a
  * flat poster fill that carries meaning without any glow, because bloom is off;
  * `line()` becomes the cartoon's ink. Nothing in src/world has to know.
  *
@@ -273,18 +273,12 @@ applyDocument(readStoredMode())
 /* ============================================================================
  * THE DAY SHADER — two injections, one hook.
  *
- * 1. TOON SHADING.
- *    Day mode needs a cel read, and it needs it on materials that already exist
- *    and are already referenced by a thousand meshes — so swapping the class for
- *    MeshToonMaterial is off the table. Instead the standard material's direct
- *    lighting term is replaced at compile time: RE_Direct is redefined to a
- *    two-value sun/shade split, and GGX is clipped into one hard highlight.
- *
- *    The ramp edge is widened by fwidth(), so the terminator stays a clean curve
- *    at every distance instead of stair-stepping across a roof. Shadows come for
- *    free: lights_fragment_begin has already multiplied directLight.color by the
- *    shadow term before RE_Direct sees it, so a shadowed face simply drops to
- *    the ambient floor — which is exactly what a cartoon shadow is.
+ * 1. STRUCTURAL LIGHTING.
+ *    The standard material's direct lighting term is replaced at compile time,
+ *    retaining the shared materials used throughout the city. A diffuse shoulder
+ *    keeps curved equipment and chamfers readable; an unquantized GGX lobe
+ *    separates metal from rough masonry. Shadow visibility has already been
+ *    applied to directLight.color, so the cool indirect floor survives in shade.
  *
  * 2. PER-INSTANCE COLOUR.
  *    The plaza's 1024 page frames, the WAL insert ring, the lock partitions, the
@@ -306,48 +300,31 @@ applyDocument(readStoredMode())
  * and never confuses the two programs.
  * ==========================================================================*/
 
-const TOON_GLSL = /* glsl */ `
-void RE_Direct_Toon( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {
+const DAYLIGHT_GLSL = /* glsl */ `
+float pgDayDiffuse( float dotNL, float up ) {
+	float sun = dotNL * 0.72 + sqrt( dotNL ) * 0.28;
+	return sun * ( 0.86 + 0.12 * up );
+}
 
+void RE_Direct_Daylight( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {
 	float dotNL = saturate( dot( geometryNormal, directLight.direction ) );
-
-	// The high threshold isolates the one wall aimed at the low sun. Roofs and
-	// crossing walls catch the middle band; the return side stays genuinely cool.
-	//
-	// The edge width follows the screen-space gradient of dotNL so each
-	// terminator stays about one pixel wide instead of aliasing at distance.
-	float w = fwidth( dotNL ) * 0.9 + 0.012;
-	float sun = 0.55 * smoothstep( 0.14 - w, 0.14 + w, dotNL )
-	          + 0.45 * smoothstep( 0.68 - w, 0.68 + w, dotNL );
-
-	// The third tone a drawn city needs is the roof, and no N·L threshold can
-	// find it — a roof and a wall can share a dot product. This lifts faces that
-	// point at the sky, in WORLD space: the fragment prefix declares viewMatrix,
-	// and multiplying a vector from the left by a matrix is multiplying by its
-	// transpose, which for the orthonormal rotation of a view matrix is its
-	// inverse. So this is the world normal for one mat4 multiply.
+	// The inverse view rotation distinguishes sky-facing roofs from walls with
+	// the same sun angle. The lift is bounded and cannot light a back-facing wall.
 	vec3 worldN = normalize( ( vec4( geometryNormal, 0.0 ) * viewMatrix ).xyz );
 	float up = smoothstep( 0.55, 0.85, worldN.y );
-
-	float graze = 0.14 * smoothstep( 0.02, 0.14, dotNL );
-	vec3 irradiance = ( graze + 0.66 * sun + 0.20 * sun * up ) * directLight.color;
-
-	// One clipped highlight instead of a smooth lobe: glass and metal still read
-	// as glass and metal, but as a cartoon would draw them. Gated on roughness,
-	// because without the gate matte stone gets a blown-white rim that reads as
-	// neon — it was the highest-contrast feature on every wall in the city.
-	vec3 spec = irradiance * BRDF_GGX_Multiscatter( directLight.direction, geometryViewDir, geometryNormal, material );
-	float specLum = dot( spec, vec3( 0.2126, 0.7152, 0.0722 ) );
-	float gloss = 1.0 - smoothstep( 0.35, 0.75, material.roughness );
-	reflectedLight.directSpecular += spec * smoothstep( 0.035, 0.09, specLum ) * gloss;
-
+	vec3 irradiance = pgDayDiffuse( dotNL, up ) * directLight.color;
+	// Specular keeps the physical incident angle and a continuous lobe. Rough
+	// stone receives a restrained sheen; polished machinery retains its highlight.
+	vec3 spec = dotNL * directLight.color * BRDF_GGX_Multiscatter( directLight.direction, geometryViewDir, geometryNormal, material );
+	float gloss = 1.0 - smoothstep( 0.35, 0.85, material.roughness );
+	reflectedLight.directSpecular += spec * mix( 0.24, 1.0, gloss );
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseContribution );
 }
 #undef RE_Direct
-#define RE_Direct RE_Direct_Toon
+#define RE_Direct RE_Direct_Daylight
 `
 
-const TOON_ANCHOR = '#include <lights_physical_pars_fragment>'
+const DAYLIGHT_ANCHOR = '#include <lights_physical_pars_fragment>'
 const VCOLOR_ANCHOR = '#include <color_fragment>'
 
 /* ============================================================================
@@ -651,7 +628,7 @@ export interface ThemeShaderSource {
 /**
  * Patch one material's source for the current mode.
  *
- * The toon ramp and the per-instance colour remap are daylight devices and are
+ * The diffuse response and per-instance colour remap are daylight devices and are
  * skipped at night. The surface term is not: it is multiplicative, so it is
  * correct in both modes, and night is the only mode that has no other way to
  * tell a wall from a slab once the neon is off.
@@ -659,7 +636,7 @@ export interface ThemeShaderSource {
 function patchThemeShader(shader: ThemeShaderSource, surface: boolean): void {
   let f = shader.fragmentShader
   if (airFor(mode).toon) {
-    if (f.indexOf(TOON_ANCHOR) >= 0) f = f.replace(TOON_ANCHOR, TOON_ANCHOR + '\n' + TOON_GLSL)
+    if (f.indexOf(DAYLIGHT_ANCHOR) >= 0) f = f.replace(DAYLIGHT_ANCHOR, DAYLIGHT_ANCHOR + '\n' + DAYLIGHT_GLSL)
     // The replacement is inert unless the material declares vertex colours: the
     // body it substitutes carries the same #if guards as the chunk it replaces.
     if (f.indexOf(VCOLOR_ANCHOR) >= 0) f = f.replace(VCOLOR_ANCHOR, VCOLOR_BODY)
@@ -815,15 +792,20 @@ interface MatSpec {
   surface: boolean
 }
 
+function daylightRoughness(authored: number, masonry: boolean): number {
+  return masonry ? Math.max(0.66, authored) : Math.max(0.16, authored)
+}
+
+function daylightMetalness(authored: number, masonry: boolean): number {
+  return masonry ? authored * 0.25 : authored
+}
+
 function paintMat(m: THREE.MeshStandardMaterial, s: MatSpec, target: ThemeMode): void {
   const daylight = daylightFor(target)
   if (daylight > 0) {
     m.color.setHex(target === 'day' ? daySurface(s.color, s.key) : clockSurface(s.color, daylight, s.key))
-    // A cel-shaded surface is matte by definition; what little variation is left
-    // drives the size of the single highlight, so roughness is compressed rather
-    // than flattened. Metal has no place in a cartoon and is nearly removed.
-    m.roughness = THREE.MathUtils.lerp(s.roughness, Math.min(1, s.roughness * 0.55 + 0.42), daylight)
-    m.metalness = THREE.MathUtils.lerp(s.metalness, s.metalness * 0.25, daylight)
+    m.roughness = THREE.MathUtils.lerp(s.roughness, daylightRoughness(s.roughness, s.surface), daylight)
+    m.metalness = THREE.MathUtils.lerp(s.metalness, daylightMetalness(s.metalness, s.surface), daylight)
     m.emissive.setHex(target === 'day' ? dayEmissive(s.emissive) : clockEmissive(s.emissive, daylight))
   } else {
     m.color.setHex(s.surface ? nightSurface(s.color) : s.color)
@@ -1065,9 +1047,10 @@ export function paintSceneMaterial(m: THREE.Material, target: ThemeMode): void {
   }
 
   const lit = isStandard(m)
-  // Only lit structure is masonry. An unlit basic material is either meaning or
-  // a decal, and a module can opt out of the term explicitly.
-  const surface = lit && ud.pgNoSurface !== true && basic.vertexColors !== true
+  /* Classify from the authored material, as the theme cache does. Using the
+   * repainted metalness would change the material family on a later toggle. */
+  const authoredMetalness = night.metalness ?? std.metalness
+  const surface = lit && ud.pgNoSurface !== true && basic.vertexColors !== true && authoredMetalness < 0.45
   installThemeShader(m, target, surface)
 
   const hasColor = (basic.color as THREE.Color | undefined) !== undefined
@@ -1121,12 +1104,12 @@ export function paintSceneMaterial(m: THREE.Material, target: ThemeMode): void {
     if (night.roughness !== undefined) {
       std.roughness = THREE.MathUtils.lerp(
         night.roughness,
-        Math.min(1, night.roughness * 0.55 + 0.42),
+        daylightRoughness(night.roughness, surface),
         daylight,
       )
     }
     if (night.metalness !== undefined) {
-      std.metalness = THREE.MathUtils.lerp(night.metalness, night.metalness * 0.25, daylight)
+      std.metalness = THREE.MathUtils.lerp(night.metalness, daylightMetalness(night.metalness, surface), daylight)
     }
   }
 }

--- a/src/core/themes.ts
+++ b/src/core/themes.ts
@@ -251,7 +251,7 @@ export interface Atmosphere {
   daylight: boolean
   stars: boolean
   clouds: boolean
-  /** Toon ramp on every MeshStandardMaterial. */
+  /** Stylized daylight response; the legacy name also selects day UI colours. */
   toon: boolean
 }
 
@@ -307,14 +307,10 @@ export const ATMOSPHERE: Record<CuratedThemeMode, Atmosphere> = {
   day: {
     // ACES at a daylight exposure crushes saturation into pastel — exactly the
     // "night theme with the lights turned up" failure. Khronos PBR Neutral
-    // holds hue and saturation and rolls the top end off instead of clipping,
-    // which is what a poster-flat city needs.
+    // holds hue and saturation and rolls the top end off instead of clipping.
     toneMapping: 'neutral',
-    // Under 1. The whole budget here is arithmetic: ambient + the toon ramp's
-    // brightest band must land near 1.0 on a 0.55-albedo stone, or the city
-    // clips to white and the ink lines have nothing to draw against. Measured
-    // on the establishing shot: hemisphere 0.62 + key 1.35 gives 0.90–1.30
-    // irradiance, and 0.92 exposure brings the top of that back under the knee.
+    // Keep material colour below the highlight shoulder; the low sun and cool
+    // indirect floor establish shape without an exposure-dependent palette.
     exposure: 1.0,
     /*
      * Aerial perspective begins at 264 m and finishes at 1,897.5 m. Across the
@@ -328,11 +324,11 @@ export const ATMOSPHERE: Record<CuratedThemeMode, Atmosphere> = {
     heightFogFalloff: 0.018,
     fogColor: DAY_PALETTE.fog,
     plateFogScale: 0.84,
-    hemiSky: 0xa7c6e8,
-    hemiGround: 0x687f9d,
-    hemiIntensity: 0.98,
-    keyColor: 0xffc47d,
-    keyIntensity: 2.4,
+    hemiSky: 0xb0cee9,
+    hemiGround: 0x7d8999,
+    hemiIntensity: 0.82,
+    keyColor: 0xffd6a3,
+    keyIntensity: 2.25,
     /*
      * North-west at 8.4°. A one-metre object casts 6.81 m across the ground;
      * the backend row therefore stripes the plaza to the south-east, and the
@@ -347,12 +343,12 @@ export const ATMOSPHERE: Record<CuratedThemeMode, Atmosphere> = {
     shadowIntensity: 0.84,
     shadows: true,
     fillColor: 0x769bc6,
-    fillIntensity: 0.18,
+    fillIntensity: 0.28,
     fillPos: [420, 220, 360],
     walGlow: 0,
     yardGlow: 0,
-    noBloomHemi: 0.98,
-    noBloomFill: 0.18,
+    noBloomHemi: 0.82,
+    noBloomFill: 0.28,
     noBloomWalGlow: 0,
     noBloomYardGlow: 0,
     // OFF, and it has to be off rather than merely quiet. Several districts

--- a/src/engine/renderer.test.ts
+++ b/src/engine/renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { AO_BLEND_INTENSITY, FIDELITY_PRESETS, QUALITY_PRESETS } from './renderer'
+import { AO_BLEND_INTENSITY, FIDELITY_PRESETS, QUALITY_PRESETS, ShadowRefreshSchedule } from './renderer'
 import { LIGHT_SHAFT_PRESETS } from './light-shafts'
 import type { QualitySettings } from '../core/types'
 
@@ -33,6 +33,31 @@ describe('quality degradation ladder', () => {
     expect(lastBloomOn.pixelRatio).toBeLessThan(presets[0].pixelRatio)
     expect(lastBloomOn.antialias).toBe(false)
     expect(lastBloomOn.shadows).toBe(false)
+  })
+})
+
+describe('animated shadow refresh', () => {
+  it('refreshes on first use and bounds medium redraws independently of frame rate', () => {
+    for (const fps of [30, 60, 120]) {
+      const schedule = new ShadowRefreshSchedule()
+      const interval = FIDELITY_PRESETS.medium.shadowUpdateInterval
+      expect(schedule.advance(0, interval)).toBe(true)
+      let refreshes = 0
+      for (let frame = 0; frame < fps; frame++) {
+        if (schedule.advance(1 / fps, interval)) refreshes++
+      }
+      expect(refreshes).toBeGreaterThanOrEqual(7)
+      expect(refreshes).toBeLessThanOrEqual(8)
+    }
+  })
+
+  it('uses the new tier budget immediately and does not replay missed refreshes', () => {
+    const schedule = new ShadowRefreshSchedule()
+    expect(schedule.advance(0, 1 / 8)).toBe(true)
+    expect(schedule.advance(0.01, 1 / 8)).toBe(false)
+    expect(schedule.advance(0.01, 0)).toBe(true)
+    expect(schedule.advance(4, 1 / 8)).toBe(true)
+    expect(schedule.advance(0.01, 1 / 8)).toBe(false)
   })
 })
 
@@ -85,5 +110,13 @@ describe('rendering fidelity ladder', () => {
     expect(high.shadowMapSize).toBeGreaterThan(medium.shadowMapSize)
     expect(ultra.shadowMapSize).toBeGreaterThanOrEqual(high.shadowMapSize)
     expect(ultra.shadowRadius).toBeGreaterThan(high.shadowRadius)
+  })
+
+  it('retains medium sun shadows with a reduced refresh budget', () => {
+    expect(QUALITY_PRESETS.medium.shadows).toBe(true)
+    expect(FIDELITY_PRESETS.medium.shadowMapSize).toBeLessThan(FIDELITY_PRESETS.high.shadowMapSize)
+    expect(FIDELITY_PRESETS.medium.shadowUpdateInterval).toBeGreaterThanOrEqual(0.1)
+    expect(FIDELITY_PRESETS.high.shadowUpdateInterval).toBeLessThan(FIDELITY_PRESETS.medium.shadowUpdateInterval)
+    expect(FIDELITY_PRESETS.ultra.shadowUpdateInterval).toBe(0)
   })
 })

--- a/src/engine/renderer.ts
+++ b/src/engine/renderer.ts
@@ -41,7 +41,7 @@ import { waterReflectionScale } from './water'
  * a glow is invisible against a bright sky), and tone mapping moves from ACES
  * to Khronos PBR Neutral — ACES at a daylight exposure washes saturated colour into
  * pastel, which is precisely the failure this mode exists to avoid. Structure
- * is cel-shaded by core/theme.ts and outlined in ink. See core/themes.ts.
+ * uses continuous stylized PBR and selective ink. See core/themes.ts.
  *
  * COLOUR PIPELINE — the part everybody gets wrong.
  *   Direct path ('low' night): renderer.render() draws to the default framebuffer,
@@ -136,7 +136,7 @@ export const QUALITY_PRESETS: Record<QualityLevel, QualitySettings> = {
     level: 'medium',
     pixelRatio: DPR_CAP.medium,
     bloom: true,
-    shadows: false,
+    shadows: true,
     maxParticles: SEMANTIC_PARTICLE_BUDGET,
     maxLabels: SEMANTIC_LABEL_BUDGET,
     antialias: false,
@@ -174,6 +174,8 @@ export interface FidelitySettings {
   aoDenoiseSamples: number
   shadowMapSize: number
   shadowRadius: number
+  /** Seconds between animated-caster refreshes; zero refreshes every frame. */
+  shadowUpdateInterval: number
 }
 
 /**
@@ -191,6 +193,7 @@ export const FIDELITY_PRESETS: Record<QualityLevel, FidelitySettings> = {
     aoDenoiseSamples: 0,
     shadowMapSize: 1024,
     shadowRadius: 1,
+    shadowUpdateInterval: 0,
   },
   reduced: {
     environment: false,
@@ -202,6 +205,7 @@ export const FIDELITY_PRESETS: Record<QualityLevel, FidelitySettings> = {
     aoDenoiseSamples: 0,
     shadowMapSize: 1024,
     shadowRadius: 1,
+    shadowUpdateInterval: 0,
   },
   medium: {
     environment: true,
@@ -213,6 +217,7 @@ export const FIDELITY_PRESETS: Record<QualityLevel, FidelitySettings> = {
     aoDenoiseSamples: 4,
     shadowMapSize: 1024,
     shadowRadius: 1,
+    shadowUpdateInterval: 1 / 8,
   },
   high: {
     environment: true,
@@ -224,6 +229,7 @@ export const FIDELITY_PRESETS: Record<QualityLevel, FidelitySettings> = {
     aoDenoiseSamples: 6,
     shadowMapSize: 1536,
     shadowRadius: 1.7,
+    shadowUpdateInterval: 1 / 30,
   },
   ultra: {
     environment: true,
@@ -235,7 +241,20 @@ export const FIDELITY_PRESETS: Record<QualityLevel, FidelitySettings> = {
     aoDenoiseSamples: 8,
     shadowMapSize: 2048,
     shadowRadius: 2.5,
+    shadowUpdateInterval: 0,
   },
+}
+
+/** Refresh animated casters at a bounded cadence without catch-up draws. */
+export class ShadowRefreshSchedule {
+  private elapsed = Infinity
+
+  advance(dt: number, interval: number): boolean {
+    this.elapsed += dt
+    if (this.elapsed < interval) return false
+    this.elapsed = 0
+    return true
+  }
 }
 
 /** Where we start before adaptive quality has an opinion. */
@@ -313,7 +332,8 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
   // what we actually get, so the console stays clean and the code stays honest.
   renderer.shadowMap.type = THREE.PCFShadowMap
   renderer.shadowMap.enabled = quality.shadows && air.shadows
-  renderer.info.autoReset = true
+  renderer.shadowMap.autoUpdate = false
+  renderer.info.autoReset = false
 
   const dom = renderer.domElement
   dom.style.display = 'block'
@@ -345,9 +365,8 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
   let environmentKey: string | null = null
 
   function applyEnvironmentIntensity(): void {
-    // Day keeps the poster-flat cel bands; night gives glossy machinery enough
-    // sky response to read without making matte structure luminous.
-    scene.environmentIntensity = air.daylight ? 0.18 : 0.55
+    // Sky reflections distinguish machinery from the matte mineral surfaces.
+    scene.environmentIntensity = air.daylight ? 0.32 : 0.55
   }
 
   function refreshEnvironment(force = false): void {
@@ -415,8 +434,7 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
   /* ---- lighting rig -----------------------------------------------------*/
 
   // Sky/ground bounce. Cheap, and it keeps north-facing walls from going black.
-  // In daylight it is doing most of the work: it is the cool ambient floor the toon
-  // ramp's darkest band lands on, which is what stops cel shadows going to mud.
+  // Cool indirect light remains visible inside the warm sun's cast shadows.
   const hemi = new THREE.HemisphereLight(air.hemiSky, air.hemiGround, air.hemiIntensity)
   scene.add(hemi)
 
@@ -455,11 +473,11 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
    * where a beam finally casts a beam-shaped shadow.
    *
    * Three things keep that from costing frames. The whole mechanism is inert
-   * unless key.castShadow is on, which is high and ultra only. The centre is
+   * unless key.castShadow is on and the tier exceeds medium. The centre is
    * snapped to the shadow map's own texel grid, without which the shadows
-   * crawl over every static surface as the camera moves. And the refit — and
-   * with it the extra shadow pass — only happens when that snapped centre
-   * actually changes, so a camera standing still pays nothing.
+   * crawl over every static surface as the camera moves. Refits happen only
+   * when that snapped centre changes; animated casters have a separate bounded
+   * refresh cadence. Medium keeps the city-wide fit when the camera moves.
    * -------------------------------------------------------------------*/
 
   /** Half-width, in metres, of the box the near cascade covers. */
@@ -472,6 +490,7 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
   const shadowFocus = new THREE.Vector3()
   const shadowSnapped = new THREE.Vector3(Infinity, Infinity, Infinity)
   let shadowSpan = 0
+  const shadowSchedule = new ShadowRefreshSchedule()
 
   function fitShadowCamera(cx = 0, cz = 0, span = 0): void {
     // Mirror DirectionalLightShadow.updateMatrices() so the fit is expressed in
@@ -525,7 +544,7 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
     if (!key.castShadow) return
 
     const eye = Math.max(2, camera.position.y)
-    if (eye > NEAR_SPAN_CEILING) {
+    if (quality.level === 'medium' || eye > NEAR_SPAN_CEILING) {
       if (shadowSpan === 0) return
       shadowSpan = 0
       shadowSnapped.set(Infinity, Infinity, Infinity)
@@ -1093,6 +1112,9 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
   let themeRestored = false
 
   function render(dt: number, rawDt?: number): void {
+    /* All beauty, reflection, shadow and post-processing draws belong to one
+     * frame. Per-render resets previously exposed only the final screen quad. */
+    renderer.info.reset()
     if (!themeRestored) {
       themeRestored = true
       applyStoredThemeMode()
@@ -1109,6 +1131,9 @@ export function createRenderer(container: HTMLElement, bus: Bus): RendererApi {
     fps = damp(fps, 1 / real, 2.5, Math.min(real, 0.5))
 
     updateShadowFit()
+    if (key.castShadow && shadowSchedule.advance(real, FIDELITY_PRESETS[quality.level].shadowUpdateInterval)) {
+      renderer.shadowMap.needsUpdate = true
+    }
 
     if (useComposer() && composer) composer.render(d)
     else renderer.render(scene, camera)


### PR DESCRIPTION
## Summary
- Continuous daylight diffuse response and smooth GGX highlights.
- Preserve authored machinery metalness/roughness and matte masonry.
- Add bounded medium-quality sun shadows and selective structural bevels.
- Correct frame counters to include all rendering passes.

Part of #12; retain the issue until the remaining daylight art acceptance passes. Part of #10 / Sprint 1.

## Verification
57 focused tests, typecheck and production build passed. Behavioral shadow-cadence tests cover 30/60/120 fps and transitions. Combined browser captures report installed baked light and no application exceptions. Further high/medium closeups and night acceptance are coordinated by QA; exact-head CI and substantive REV review remain mandatory.

## Scope and qualifications
No dependencies, assets or simulation changes. SwiftShader capture frame rates are not hardware performance benchmarks. The first inspected daylight scene still needs a separate structural-value art pass; these material/cost changes are groundwork, not the final premium look.