### PR TITLE
chore: patch nanoid advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgsimcity",
-  "version": "0.39.6",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pgsimcity",
-      "version": "0.39.6",
+      "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.4",
@@ -1169,9 +1169,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
Update the inherited transitive development dependency nanoid from 3.3.16 to the compatible 3.3.18 patch, resolving GHSA-2v37-7h3g-55p8. Synchronize stale lockfile package-version metadata with package.json.

Closes #20. Part of #10 / Sprint 1.

## Verification
- npm audit: zero known vulnerabilities.
- 1,010 non-browser tests passed.
- Typecheck and production build passed.
- Only the lockfile changed; no runtime dependency was added and no broad or forced upgrade was performed.

CI and substantive review of the complete lockfile diff are required before merge.