### PR TITLE
feat: add a vacuum investigation lesson

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgsimcity",
-  "version": "0.39.6",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pgsimcity",
-      "version": "0.39.6",
+      "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.4",

--- a/src/core/analytics.test.ts
+++ b/src/core/analytics.test.ts
@@ -9,6 +9,7 @@ import {
   listenForAnalyticsInteractions,
   outboundTrackingAllowed,
   panelSlug,
+  trackVacuumLessonProgress,
 } from './analytics'
 import { createBus } from './bus'
 
@@ -51,6 +52,20 @@ describe('analytics attribution', () => {
 })
 
 describe('analytics event queue', () => {
+  it('allowlists lesson events and exports no notebook, SQL, or arbitrary input', () => {
+    const plausible = vi.fn()
+    const tracker = createAnalyticsTracker('city', plausible)
+    trackVacuumLessonProgress(tracker, {
+      event: 'recovery-verified', mode: 'challenge', notes: 'private note', sql: 'select secret',
+    })
+    trackVacuumLessonProgress(tracker, { event: 'private note', mode: 'guided' })
+    trackVacuumLessonProgress(tracker, { event: 'started', mode: 'private note' })
+    trackVacuumLessonProgress(tracker, { event: '__proto__', mode: 'guided' })
+    expect(plausible.mock.calls).toEqual([
+      ['Lesson Recovery Verified', { props: { entrypoint: 'city', lesson: 'vacuum-blockade', mode: 'challenge' } }],
+    ])
+  })
+
   it('falls back to an inert window queue when the provider is unavailable', () => {
     const target: { plausible?: ReturnType<typeof createPlausibleQueue> } = {}
     const dispatch = createPlausibleDispatcher(target)

--- a/src/core/analytics.ts
+++ b/src/core/analytics.ts
@@ -32,6 +32,21 @@ export interface AnalyticsTracker {
   track(name: string, props?: AnalyticsProperties, interactive?: boolean): void
 }
 
+export function trackVacuumLessonProgress(
+  tracker: AnalyticsTracker,
+  progress: { event: string; mode: string; [key: string]: unknown },
+): void {
+  if (progress.mode !== 'guided' && progress.mode !== 'challenge') return
+  const names = new Map([
+    ['started', 'Lesson Started'],
+    ['hint-used', 'Lesson Hint Used'],
+    ['evidence-collected', 'Lesson Evidence Collected'],
+    ['recovery-verified', 'Lesson Recovery Verified'],
+  ])
+  const name = names.get(progress.event)
+  if (name) tracker.track(name, { lesson: 'vacuum-blockade', mode: progress.mode })
+}
+
 export interface Analytics extends AnalyticsTracker {
   listen(bus: Bus): () => void
   dispose(): void

--- a/src/core/lesson-route.test.ts
+++ b/src/core/lesson-route.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { installLessonRoutes, lessonHref, lessonMode, lessonShareUrl } from './lesson-route'
+
+describe('shareable vacuum investigation', () => {
+  it('shares only the lesson and mode, dropping current query input and replay state', () => {
+    expect(lessonShareUrl('https://example.org/PGSimCity/?sql=private#replay/private', 'challenge'))
+      .toBe('https://example.org/PGSimCity/#lesson/vacuum-blockade/challenge')
+  })
+
+  it.each(['guided', 'challenge'] as const)('round-trips %s without session data', (mode) => {
+    expect(lessonMode(lessonHref(mode))).toBe(mode)
+    expect(lessonHref(mode)).toBe(`#lesson/vacuum-blockade/${mode}`)
+  })
+
+  it.each(['', '#lesson/vacuum-blockade', '#lesson/vacuum-blockade/expert',
+    '#lesson/vacuum-blockade/challenge?sql=select', '#lesson/unknown/guided',
+    '#lesson/vacuum-blockade/%67uided'])('ignores unsupported input %s', (hash) => {
+    expect(lessonMode(hash)).toBeNull()
+  })
+
+  it('opens the chosen mode on arrival or hash change and removes its listener', () => {
+    const target = new EventTarget()
+    const location = { hash: lessonHref('challenge') }
+    const open = vi.fn()
+    const dispose = installLessonRoutes({ target, location, open })
+    expect(open).toHaveBeenCalledExactlyOnceWith('challenge')
+    location.hash = lessonHref('guided')
+    target.dispatchEvent(new Event('hashchange'))
+    expect(open).toHaveBeenLastCalledWith('guided')
+    location.hash = '#component/storage.table.sessions'
+    target.dispatchEvent(new Event('hashchange'))
+    expect(open).toHaveBeenCalledTimes(2)
+    dispose()
+    location.hash = lessonHref('challenge')
+    target.dispatchEvent(new Event('hashchange'))
+    expect(open).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/core/lesson-route.ts
+++ b/src/core/lesson-route.ts
@@ -1,0 +1,34 @@
+export type LessonMode = 'guided' | 'challenge'
+
+const PREFIX = '#lesson/vacuum-blockade/'
+
+export function lessonHref(mode: LessonMode): string {
+  return `${PREFIX}${mode}`
+}
+
+export function lessonShareUrl(currentHref: string, mode: LessonMode): string {
+  const url = new URL(currentHref)
+  url.search = ''
+  url.hash = lessonHref(mode)
+  return url.href
+}
+
+export function lessonMode(hash: string): LessonMode | null {
+  if (hash === lessonHref('guided')) return 'guided'
+  if (hash === lessonHref('challenge')) return 'challenge'
+  return null
+}
+
+export function installLessonRoutes(options: {
+  target: Pick<EventTarget, 'addEventListener' | 'removeEventListener'>
+  location: { hash: string }
+  open(mode: LessonMode): void
+}): () => void {
+  const sync = (): void => {
+    const mode = lessonMode(options.location.hash)
+    if (mode) options.open(mode)
+  }
+  options.target.addEventListener('hashchange', sync)
+  sync()
+  return () => options.target.removeEventListener('hashchange', sync)
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1166,6 +1166,7 @@ export interface VacuumBlockadeDecisionState extends ScenarioDecisionBase {
   pagesAtDecision: number
   vacuumRunsAtDecision: number
   landfillAtDecision: number
+  landfillAtRelease: number | null
   deadTuplesAdded: number
   pagesAdded: number
   blockedVacuumWorkers: number

--- a/src/main.ts
+++ b/src/main.ts
@@ -335,7 +335,7 @@ async function boot(): Promise<void> {
     createHelp(uiCtx),
     createControls(uiCtx),
     createInspector(uiCtx),
-    createTour(uiCtx),
+    createTour(uiCtx, { onInvestigate: () => vacuumLesson.open() }),
     createSearch(uiCtx),
     createCityWords(uiCtx),
     /* Right-click. The camera gave up that button when rotation moved to

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,8 @@ import * as THREE from 'three'
 import './styles/tokens.css'
 import './styles/ui.css'
 
-import { startAnalytics } from './core/analytics'
+import { startAnalytics, trackVacuumLessonProgress } from './core/analytics'
+import { installLessonRoutes } from './core/lesson-route'
 import { createBus } from './core/bus'
 import { CLAIM_VALUES } from './core/claims'
 import { createCorrectionPath, displayedClaim, protectCorrectionLink } from './core/corrections'
@@ -63,6 +64,7 @@ import { createHelp } from './ui/help'
 import { createControls } from './ui/controls'
 import { createInspector } from './ui/panel'
 import { createTour } from './ui/tour'
+import { createVacuumLesson } from './ui/vacuum-lesson'
 import { createSearch } from './ui/search'
 import { createCityWords } from './ui/city-words'
 import { createTouchpad } from './ui/touchpad'
@@ -297,8 +299,12 @@ async function boot(): Promise<void> {
     door: controlCenterWorld.door,
     hands,
   })
+  const vacuumLesson = createVacuumLesson(uiCtx, {
+    onProgress: ({ event, mode }) => trackVacuumLessonProgress(analytics, { event, mode }),
+  })
   const ui: UiModule[] = [
-    createHud(uiCtx),
+    vacuumLesson,
+    createHud(uiCtx, { onInvestigate: () => vacuumLesson.open() }),
     createTouchpad({ bus, walk }),
     controlCenter,
     createWalkUpInteraction({
@@ -515,6 +521,9 @@ async function boot(): Promise<void> {
     location: window.location,
     target: window,
   })
+  const stopLessonRoutes = installLessonRoutes({
+    target: window, location: window.location, open: (mode) => vacuumLesson.open(mode),
+  })
   frame()
 
   finishBoot(bootSurface)
@@ -534,6 +543,7 @@ async function boot(): Promise<void> {
     window.removeEventListener('keydown', resumePreferredAudio, true)
     offAudioToggle()
     stopCityComponentRoutes()
+    stopLessonRoutes()
     stopAnalytics()
     analytics.dispose()
     timer.disconnect()

--- a/src/sim/model.ts
+++ b/src/sim/model.ts
@@ -8046,6 +8046,7 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
         pagesAtDecision: 0,
         vacuumRunsAtDecision: 0,
         landfillAtDecision: 0,
+        landfillAtRelease: null,
         deadTuplesAdded: 0,
         pagesAdded: 0,
         blockedVacuumWorkers: 0,
@@ -8139,7 +8140,8 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
         }
         if (
           decision.transactionTerminated
-          && decision.deadTuplesReclaimed > 0
+          && decision.landfillAtRelease !== null
+          && av.landfill > decision.landfillAtRelease
           && !K.longRunningXact
         ) {
           decision.phase = 'recovered'
@@ -8340,6 +8342,7 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
         decision.choice = choice
         decision.correct = true
         decision.transactionTerminated = true
+        decision.landfillAtRelease = av.landfill
         setKnob('longRunningXact', false)
         decision.phase = 'outcome'
         toast(
@@ -8382,6 +8385,7 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
       && decision.phase === 'outcome'
     ) {
       decision.transactionTerminated = true
+      decision.landfillAtRelease = av.landfill
       decision.phase = 'recovering'
       setKnob('longRunningXact', false)
       return true

--- a/src/sim/vacuum-recovery.test.ts
+++ b/src/sim/vacuum-recovery.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from 'vitest'
+import { createAggregateSim } from './test-support'
+
+it('does not count pre-release vacuum collection as post-release recovery', () => {
+  const step = 1 / 3
+  const sim = createAggregateSim(step)
+  sim.runScenario('vacuum-blockade')
+  for (let i = 0; i < 180; i++) sim.update(step)
+  const decision = sim.state.scenarioDecision!
+  expect(decision.phase).toBe('ready')
+  if (decision.kind !== 'vacuum-blockade') throw new Error('wrong decision')
+  // Eligible older versions can be collected while newer versions remain pinned.
+  decision.landfillAtDecision = sim.state.autovac.landfill - 100
+  sim.chooseScenario('terminate-transaction')
+  const releasedAt = sim.state.autovac.landfill
+  sim.update(step)
+  expect(sim.state.autovac.landfill).toBe(releasedAt)
+  expect(decision.phase).not.toBe('recovered')
+  for (let i = 0; i < 2700 && decision.phase !== 'recovered'; i++) sim.update(step)
+  expect(decision.phase).toBe('recovered')
+  expect(sim.state.autovac.landfill).toBeGreaterThan(releasedAt)
+})

--- a/src/styles/tour.css
+++ b/src/styles/tour.css
@@ -288,6 +288,30 @@ body.pg-tour #hud-bottom:focus-within {
   max-width: 68ch;
 }
 
+.tour-narrate__notes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.tour-narrate__notes .pg-btn {
+  min-height: var(--tap);
+}
+
+.tour-history-open {
+  pointer-events: auto;
+}
+
+.tour-history-open[hidden],
+.tour-narrate.is-trace .tour-narrate__notes,
+body.pg-tour .tour-history-open,
+body.pg-trace .tour-history-open,
+body.pg-invite .tour-history-open,
+body.pg-vacuum-lesson .tour-history-open {
+  display: none;
+}
+
 .tour-narrate__sql,
 .tour-narrate__hint,
 .tour-narrate__strip,

--- a/src/styles/vacuum-lesson.css
+++ b/src/styles/vacuum-lesson.css
@@ -1,11 +1,11 @@
 .vacuum-lesson {
   position: fixed;
   z-index: var(--z-floating-overlay);
-  inset: calc(78px + var(--safe-t)) calc(18px + var(--safe-r)) auto auto;
+  inset: var(--vacuum-top, calc(78px + var(--safe-t))) calc(18px + var(--safe-r)) auto auto;
   display: flex;
   flex-direction: column;
   width: min(410px, calc(100vw - 36px - var(--safe-l) - var(--safe-r)));
-  max-height: calc(100dvh - 172px - var(--safe-t) - var(--safe-b));
+  max-height: calc(100dvh - var(--vacuum-top, 78px) - 94px - var(--safe-b));
   color: var(--ink);
   background: var(--bg-panel-solid);
   border: 1px solid var(--line-hard);

--- a/src/styles/vacuum-lesson.css
+++ b/src/styles/vacuum-lesson.css
@@ -1,0 +1,280 @@
+.vacuum-lesson {
+  position: fixed;
+  z-index: var(--z-floating-overlay);
+  inset: calc(78px + var(--safe-t)) calc(18px + var(--safe-r)) auto auto;
+  display: flex;
+  flex-direction: column;
+  width: min(410px, calc(100vw - 36px - var(--safe-l) - var(--safe-r)));
+  max-height: calc(100dvh - 172px - var(--safe-t) - var(--safe-b));
+  color: var(--ink);
+  background: var(--bg-panel-solid);
+  border: 1px solid var(--line-hard);
+  border-top: 3px solid var(--c-vacuum);
+  border-radius: 12px;
+  box-shadow: 0 18px 60px rgb(0 0 0 / 22%);
+  font: 13px/1.5 var(--f-ui);
+  pointer-events: auto;
+}
+
+.vacuum-lesson[hidden],
+.vacuum-lesson [hidden],
+body.pg-vacuum-lesson .hud-decision,
+body.pg-vacuum-lesson .tour-first,
+body.pg-vacuum-lesson .tour-narrate {
+  display: none;
+}
+
+.vacuum-lesson__head {
+  position: relative;
+  flex: 0 0 auto;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--line-hair);
+}
+
+.vacuum-lesson__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  padding-right: 48px;
+  color: var(--ink-dim);
+  font-size: 11px;
+}
+
+.vacuum-lesson__clock {
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.vacuum-lesson__close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+}
+
+.vacuum-lesson h2 {
+  margin: 12px 0 8px;
+  font-size: 22px;
+  line-height: 1.2;
+  font-weight: 680;
+  letter-spacing: -0.035em;
+}
+
+.vacuum-lesson h2:focus {
+  outline: none;
+}
+
+.vacuum-lesson h3 {
+  margin: 5px 0 10px;
+  font-size: 15px;
+  line-height: 1.3;
+}
+
+.vacuum-lesson p {
+  margin: 8px 0;
+}
+
+.vacuum-lesson__step {
+  color: var(--ink-dim);
+  font-size: 12px;
+}
+
+.vacuum-lesson__body {
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding: 16px 20px 18px;
+}
+
+.vacuum-lesson__evidence {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 7px;
+  margin-bottom: 16px;
+}
+
+.vacuum-lesson__evidence-button {
+  min-height: 44px;
+  padding: 9px 10px;
+  color: var(--ink);
+  background: var(--bg-raise);
+  border: 1px solid var(--line-soft);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.vacuum-lesson__evidence-button[aria-pressed='true'],
+.vacuum-lesson__answer[aria-pressed='true'] {
+  border-color: var(--c-vacuum);
+  box-shadow: inset 3px 0 var(--c-vacuum);
+}
+
+.vacuum-lesson button:focus-visible,
+.vacuum-lesson summary:focus-visible,
+.vacuum-lesson textarea:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+}
+
+.vacuum-lesson .pg-btn {
+  min-height: 36px;
+  height: auto;
+  padding: 8px 11px;
+  white-space: normal;
+  line-height: 1.4;
+  text-align: left;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.vacuum-lesson .pg-btn:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.vacuum-lesson__detail,
+.vacuum-lesson__causes,
+.vacuum-lesson__decision,
+.vacuum-lesson__observation {
+  margin: 0 0 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line-hair);
+}
+
+.vacuum-lesson__source,
+.vacuum-lesson__guidance,
+.vacuum-lesson__feedback,
+.vacuum-lesson__retry p,
+.vacuum-lesson__notes > p {
+  color: var(--ink-dim);
+  font-size: 12px;
+}
+
+.vacuum-lesson__reading {
+  font-variant-numeric: tabular-nums;
+}
+
+.vacuum-lesson__primary {
+  border-color: var(--c-vacuum);
+}
+
+.vacuum-lesson__answer {
+  display: block;
+  width: 100%;
+  margin: 6px 0;
+}
+
+.vacuum-lesson__announcement:empty {
+  display: none;
+}
+
+.vacuum-lesson__announcement {
+  color: var(--ink-dim);
+  font-size: 12px;
+}
+
+.vacuum-lesson__tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 12px 0;
+}
+
+.vacuum-lesson__notes {
+  margin: 16px 0;
+}
+
+.vacuum-lesson__notes summary {
+  min-height: 36px;
+  padding: 7px 0;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.vacuum-lesson__notebook {
+  padding-left: 20px;
+  color: var(--ink-dim);
+  font-size: 12px;
+}
+
+.vacuum-lesson__notebook strong {
+  color: var(--ink);
+}
+
+.vacuum-lesson__notes label {
+  display: block;
+  margin: 12px 0 6px;
+}
+
+.vacuum-lesson textarea {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 9px;
+  color: var(--ink);
+  background: var(--bg-sunken);
+  border: 1px solid var(--line-soft);
+  border-radius: 4px;
+  font: inherit;
+  resize: vertical;
+}
+
+.vacuum-lesson__disclosure {
+  padding-top: 12px;
+  border-top: 1px solid var(--line-hair);
+  color: var(--ink-dim);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+  .tour-first--investigation {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .tour-first--investigation .tour-first__text {
+    display: grid;
+  }
+
+  .tour-first--investigation .tour-first__btns {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .tour-first--investigation .tour-first__go {
+    grid-column: 1 / -1;
+    white-space: normal;
+  }
+
+  .vacuum-lesson {
+    inset: auto calc(8px + var(--safe-r)) calc(82px + var(--safe-b)) calc(8px + var(--safe-l));
+    width: auto;
+    max-height: calc(72dvh - var(--safe-b));
+  }
+
+  .vacuum-lesson__head,
+  .vacuum-lesson__body {
+    padding: 12px 14px;
+  }
+
+  .vacuum-lesson h2 {
+    font-size: 19px;
+  }
+
+  .vacuum-lesson .pg-btn {
+    min-height: var(--tap);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vacuum-lesson *,
+  .vacuum-lesson *::before,
+  .vacuum-lesson *::after {
+    animation: none;
+    transition: none;
+    scroll-behavior: auto;
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -340,7 +340,7 @@ function vitalHistory(key: VitalKey, s: SimState): number[] {
  * FACTORY
  * ========================================================================*/
 
-export function createHud(ctx: UiContext): UiModule {
+export function createHud(ctx: UiContext, options: { onInvestigate?: () => void } = {}): UiModule {
   const bus = ctx.bus
   const looseBus = bus
   const sim = ctx.sim
@@ -494,6 +494,18 @@ export function createHud(ctx: UiContext): UiModule {
     icon('tour', 15),
     el('span', { text: 'Tour' }),
   )
+  const investigateBtn = options.onInvestigate ? el(
+    'button',
+    {
+      class: 'pg-btn hud-tool hud-investigate',
+      type: 'button',
+      title: 'Investigate a growing table, collect evidence, and verify recovery',
+      'aria-label': 'Investigate a PostgreSQL incident',
+      on: { click: options.onInvestigate },
+    },
+    icon('diagnose', 15),
+    el('span', { text: 'Investigate' }),
+  ) : null
   const traceBtn = el(
     'button',
     {
@@ -656,6 +668,7 @@ export function createHud(ctx: UiContext): UiModule {
     legalBtn,
     viewBtn,
     tourBtn,
+    investigateBtn,
     traceBtn,
     diagnoseLink,
     walkBtn,

--- a/src/ui/latency-hud.test.ts
+++ b/src/ui/latency-hud.test.ts
@@ -91,4 +91,15 @@ describe('latency HUD', () => {
     expect(requests).toEqual([{ open: true, key: 'synchronousStandbyNames' }])
     hud.dispose()
   })
+
+  it('opens the investigation from a persistent, labelled control', () => {
+    const investigate = vi.fn()
+    const hud = createHud(context(), { onInvestigate: investigate })
+    const button = document.querySelector<HTMLButtonElement>('.hud-investigate')!
+    expect(button).not.toBeNull()
+    expect(button.getAttribute('aria-label')).toBe('Investigate a PostgreSQL incident')
+    button.click()
+    expect(investigate).toHaveBeenCalledOnce()
+    hud.dispose()
+  })
 })

--- a/src/ui/timebase.test.ts
+++ b/src/ui/timebase.test.ts
@@ -125,7 +125,7 @@ describe('user-facing timebase', () => {
     tour.dispose()
   })
 
-  it('holds scenario narration for simulation time, including while paused', () => {
+  it('keeps scenario narration until reader dismissal, including while paused', () => {
     const ctx = context()
     const tour = createTour(ctx)
 
@@ -140,7 +140,10 @@ describe('user-facing timebase', () => {
       ctx.sim.update(1 / 30)
       tour.update(1 / 30)
     }
-    expect(card.classList.contains('is-out')).toBe(true)
+    expect(card.classList.contains('is-live')).toBe(true)
+    expect(card.classList.contains('is-out')).toBe(false)
+    document.querySelector<HTMLButtonElement>('[data-scenario-note="dismiss"]')!.click()
+    expect(card.classList.contains('is-live')).toBe(false)
     tour.dispose()
   })
 

--- a/src/ui/tour-entry.test.ts
+++ b/src/ui/tour-entry.test.ts
@@ -28,6 +28,57 @@ afterEach(() => {
 })
 
 describe('first investigation invitation', () => {
+  it('keeps scenario explanations beyond their former model-time expiry', () => {
+    const ctx = fixture()
+    const tour = createTour(ctx, { onInvestigate: vi.fn() })
+    modules.push(tour)
+    ctx.sim.runScenario('steady-state')
+    ctx.sim.update(1 / 30)
+    const title = document.querySelector('.tour-narrate__title')!.textContent
+    for (let frame = 0; frame < 300; frame++) {
+      ctx.sim.update(1 / 30)
+      tour.update(1 / 30)
+    }
+    vi.advanceTimersByTime(1000)
+    expect(document.querySelector('.tour-narrate')!.classList.contains('is-live')).toBe(true)
+    expect(document.querySelector('.tour-narrate__title')!.textContent).toBe(title)
+  })
+
+  it('queues later beats without replacing the reader’s current explanation and can reopen history', () => {
+    const ctx = fixture()
+    modules.push(createTour(ctx, { onInvestigate: vi.fn() }))
+    ctx.bus.emit('narrate', { title: 'First explanation', body: 'First complete qualification.', seconds: 9 })
+    ctx.bus.emit('narrate', { title: 'Second explanation', body: 'Second complete qualification.', seconds: 9 })
+    expect(document.querySelector('.tour-narrate__title')!.textContent).toBe('First explanation')
+    document.querySelector<HTMLButtonElement>('[data-scenario-note="next"]')!.click()
+    expect(document.querySelector('.tour-narrate__body')!.textContent).toBe('Second complete qualification.')
+    document.querySelector<HTMLButtonElement>('[data-scenario-note="previous"]')!.click()
+    expect(document.querySelector('.tour-narrate__title')!.textContent).toBe('First explanation')
+    document.querySelector<HTMLButtonElement>('[data-scenario-note="dismiss"]')!.click()
+    vi.advanceTimersByTime(1000)
+    expect(document.querySelector('.tour-narrate')!.classList.contains('is-live')).toBe(false)
+    document.querySelector<HTMLButtonElement>('[data-scenario-history]')!.click()
+    expect(document.querySelector('.tour-narrate__title')!.textContent).toBe('First explanation')
+    expect(document.querySelector('.tour-narrate__body')!.textContent).toBe('First complete qualification.')
+  })
+
+  it('keeps a dismissed scenario quiet while retaining later notes and their disclosure', () => {
+    const ctx = fixture()
+    modules.push(createTour(ctx, { onInvestigate: vi.fn() }))
+    ctx.sim.runScenario('work-mem-spill')
+    document.querySelector<HTMLButtonElement>('[data-scenario-note="dismiss"]')!.click()
+    ctx.bus.emit('narrate', { title: 'Later note', body: 'Full scope qualification.', seconds: 9 })
+    expect(document.querySelector('.tour-narrate')!.classList.contains('is-live')).toBe(false)
+    ctx.sim.runScenario(null)
+    document.querySelector<HTMLButtonElement>('[data-scenario-history]')!.click()
+    document.querySelector<HTMLButtonElement>('[data-scenario-note="next"]')!.click()
+    expect(document.querySelector('.tour-narrate__body')!.textContent).toBe('Full scope qualification.')
+    expect(document.querySelector<HTMLElement>('.tour-narrate__body')!.dataset.disclosure).toBe('work-mem-scenario-narration')
+    ctx.sim.reset()
+    expect(document.querySelector<HTMLButtonElement>('[data-scenario-history]')!.hidden).toBe(true)
+    expect(document.querySelector('.tour-narrate')!.classList.contains('is-live')).toBe(false)
+  })
+
   it('keeps the offer until the reader acts, then opens the investigation', () => {
     const ctx = fixture()
     const investigate = vi.fn()

--- a/src/ui/tour-entry.test.ts
+++ b/src/ui/tour-entry.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createBus } from '../core/bus'
+import { createSim } from '../sim/model'
+import { installTestDom } from '../../test/dom'
+import { createTour } from './tour'
+import type { UiContext, UiModule } from './uikit'
+
+const modules: UiModule[] = []
+
+function fixture(): UiContext {
+  const bus = createBus()
+  return {
+    bus, sim: createSim(bus), registry: { get: () => undefined },
+    getFps: () => 60, getQuality: () => ({ level: 'high' }),
+    getFlowStats: () => ({ active: 0, dropped: 0 }),
+  } as unknown as UiContext
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  const dom = installTestDom()
+  dom.mount('tour-layer')
+})
+
+afterEach(() => {
+  while (modules.length) modules.pop()!.dispose()
+  vi.useRealTimers()
+})
+
+describe('first investigation invitation', () => {
+  it('keeps the offer until the reader acts, then opens the investigation', () => {
+    const ctx = fixture()
+    const investigate = vi.fn()
+    modules.push(createTour(ctx, { onInvestigate: investigate }))
+    const start = document.querySelector<HTMLButtonElement>('.tour-first__go')!
+    expect(start.textContent).toContain('Investigate a growing table')
+    expect(window.localStorage.getItem('pgsimcity.seen')).toBeNull()
+    vi.advanceTimersByTime(120_000)
+    expect(document.querySelector('.tour-first')!.classList.contains('is-live')).toBe(true)
+    start.click()
+    expect(investigate).toHaveBeenCalledTimes(1)
+    expect(document.body.classList.contains('pg-tour')).toBe(false)
+    expect(document.querySelector('.tour-first')!.classList.contains('is-live')).toBe(false)
+    expect(window.localStorage.getItem('pgsimcity.seen')).toBe('1')
+  })
+
+  it('preserves the self-paced tour as a secondary choice', () => {
+    const ctx = fixture()
+    const investigate = vi.fn()
+    modules.push(createTour(ctx, { onInvestigate: investigate }))
+    document.querySelector<HTMLButtonElement>('.tour-first__tour')!.click()
+    expect(investigate).not.toHaveBeenCalled()
+    expect(document.body.classList.contains('pg-tour')).toBe(true)
+    expect(document.activeElement).toBe(document.querySelector('.tour-next'))
+  })
+
+  it('remembers an explicit choice to explore freely', () => {
+    const ctx = fixture()
+    modules.push(createTour(ctx, { onInvestigate: vi.fn() }))
+    document.querySelector<HTMLButtonElement>('.tour-first__no')!.click()
+    modules.pop()!.dispose()
+    modules.push(createTour(ctx, { onInvestigate: vi.fn() }))
+    expect(document.querySelector('.tour-first')!.classList.contains('is-live')).toBe(false)
+  })
+
+  it('ends a query trace and restores its baseline when another lesson takes over', () => {
+    const ctx = fixture()
+    ctx.sim.setKnob('tps', 321)
+    ctx.sim.setKnob('timeScale', 0.5)
+    modules.push(createTour(ctx))
+    ctx.bus.emit('trace:open', {})
+    document.querySelector<HTMLButtonElement>('.trace-picker__choice')!.click()
+    expect(ctx.sim.state.knobs.tps).toBe(18)
+    ctx.bus.emit('tour:stop', {})
+    expect(ctx.sim.state.knobs.tps).toBe(321)
+    expect(ctx.sim.state.knobs.timeScale).toBe(0.5)
+    expect(document.body.classList.contains('pg-trace')).toBe(false)
+  })
+})

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -259,7 +259,11 @@ function markSeen(): void {
  * FACTORY
  * ========================================================================*/
 
-export function createTour(ctx: UiContext): UiModule {
+export interface TourOptions {
+  onInvestigate?: () => void
+}
+
+export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule {
   const bus = ctx.bus
   const sim = ctx.sim
   const layer = document.getElementById('tour-layer') ?? el('div')
@@ -811,14 +815,16 @@ export function createTour(ctx: UiContext): UiModule {
 
   const firstRun = el(
     'aside',
-    { class: 'tour-first pg-panel', role: 'note' },
+    { class: `tour-first pg-panel${options.onInvestigate ? ' tour-first--investigation' : ''}`, role: 'note' },
     el(
       'div',
       { class: 'tour-first__text' },
       el('span', { class: 'pg-eyebrow', text: 'First time here?' }),
       el('p', {
         class: 'tour-first__line',
-        text: `Follow a query from connection to commit — ${STEPS.length} chapters, at your pace.`,
+        text: options.onInvestigate
+          ? 'Autovacuum is running. Why is this table still growing? Follow the evidence and test your explanation.'
+          : `Follow a query from connection to commit — ${STEPS.length} chapters, at your pace.`,
       }),
     ),
     el(
@@ -831,21 +837,28 @@ export function createTour(ctx: UiContext): UiModule {
           type: 'button',
           on: {
             click: () => {
+              markSeen()
               hideFirstRun()
-              bus.emit('tour:start', { source: 'button' })
+              if (options.onInvestigate) options.onInvestigate()
+              else bus.emit('tour:start', { source: 'button' })
             },
           },
         },
-        icon('tour', 13),
-        el('span', { text: 'Start the tour' }),
+        icon(options.onInvestigate ? 'diagnose' : 'tour', 13),
+        el('span', { text: options.onInvestigate ? 'Investigate a growing table' : 'Start the tour' }),
       ),
+      options.onInvestigate && el('button', {
+        class: 'pg-btn pg-btn--ghost tour-first__tour',
+        type: 'button', text: 'Take the tour',
+        on: { click: () => { markSeen(); hideFirstRun(); bus.emit('tour:start', { source: 'button' }) } },
+      }),
       el(
         'button',
         {
           class: 'pg-btn pg-btn--ghost tour-first__no',
           type: 'button',
-          text: 'Dismiss',
-          on: { click: () => hideFirstRun() },
+          text: options.onInvestigate ? 'Explore freely' : 'Dismiss',
+          on: { click: () => { markSeen(); hideFirstRun() } },
         },
       ),
     ),
@@ -861,13 +874,13 @@ export function createTour(ctx: UiContext): UiModule {
 
   function showFirstRun(): void {
     if (running || hasSeen()) return
-    markSeen()
+    if (!options.onInvestigate) markSeen()
     firstLive = true
     setClass(firstRun, 'is-live', true)
     // While this is up, nothing else speaks from the deck (see tour.css).
     document.body.classList.add('pg-invite')
-    // An invitation nobody answers is just furniture. It leaves on its own.
-    firstTimer = window.setTimeout(() => hideFirstRun(), FIRST_RUN_LIFE_MS)
+    // The investigation invitation remains available until the reader chooses.
+    if (!options.onInvestigate) firstTimer = window.setTimeout(() => hideFirstRun(), FIRST_RUN_LIFE_MS)
   }
 
   layer.append(firstRun, narrateCard, card)
@@ -1071,7 +1084,7 @@ export function createTour(ctx: UiContext): UiModule {
   const looseBus = bus
   cleanup.push(
     bus.on('tour:start', (p) => start(p && typeof p.chapter === 'number' ? p.chapter : 0)),
-    bus.on('tour:stop', () => stop()),
+    bus.on('tour:stop', () => { stop(); closeTrace() }),
     bus.on('trace:open', () => openTracePicker()),
     bus.on('narrate', (p) => {
       // While the tour is speaking, scenario beats stay quiet.

--- a/src/ui/tour.ts
+++ b/src/ui/tour.ts
@@ -6,7 +6,7 @@ import { createCorrectionPath, displayedClaim } from '../core/corrections'
 import { mdToHtml } from './content'
 import { clamp, reduceMotion } from '../core/util'
 import { MODEL_TIME_STRETCH, sqlFor } from '../sim/model'
-import { SCENARIOS, SCENARIO_NARRATION_SECONDS } from '../sim/scenarios'
+import { SCENARIOS } from '../sim/scenarios'
 import { MODE_IDS } from './mode-exits'
 import { TABLES } from '../world/layout'
 import { TRACE_COPY } from './trace-copy'
@@ -431,6 +431,28 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
   const traceSql = el('code', { class: 'tour-narrate__sql' })
   const traceHint = el('p', { class: 'tour-narrate__hint' })
   const stretchText = el('span', { class: 'tour-narrate__stretch' })
+  const scenarioNotes: { title: string; body: string; scenario: string | null; time: number }[] = []
+  let noteIndex = -1
+  let notesDismissed = false
+  const notePrevious = el('button', {
+    class: 'pg-btn', type: 'button', text: 'Previous note', data: { scenarioNote: 'previous' },
+    on: { click: () => { if (noteIndex > 0) { noteIndex--; paintScenarioNote() } } },
+  })
+  const noteNext = el('button', {
+    class: 'pg-btn', type: 'button', text: 'Next note', data: { scenarioNote: 'next' },
+    on: { click: () => { if (noteIndex + 1 < scenarioNotes.length) { noteIndex++; paintScenarioNote() } } },
+  })
+  const noteDismiss = el('button', {
+    class: 'pg-btn', type: 'button', text: 'Dismiss notes', data: { scenarioNote: 'dismiss' },
+    on: { click: () => { notesDismissed = true; hideNarrate(true); noteHistory.focus() } },
+  })
+  const noteHistory = el('button', {
+    class: 'pg-btn tour-history-open', type: 'button', text: 'Scenario notes', hidden: true,
+    data: { scenarioHistory: '' },
+    on: { click: () => { notesDismissed = false; paintScenarioNote(); noteDismiss.focus() } },
+  })
+  const noteControls = el('div', { class: 'tour-narrate__notes', 'aria-label': 'Scenario notes' },
+    notePrevious, noteNext, noteDismiss)
 
   const traceModeButton = (mode: TracePlayback, label: string): HTMLButtonElement =>
     el('button', {
@@ -486,10 +508,10 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
     traceHint,
     traceStrip,
     traceAgainBtn,
+    noteControls,
   )
 
   let narrateTimer = 0
-  let narrateUntil = 0
   let traceActive = false
   let traceAwaiting = false
   let traceMode: TracePlayback = 'slow'
@@ -501,8 +523,9 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
 
   const currentScenarioBeat = () => {
     if (traceActive) return null
-    const scenario = sim.state.scenario
-      ? SCENARIOS.find((candidate) => candidate.id === sim.state.scenario)
+    const scenarioId = scenarioNotes[noteIndex]?.scenario ?? sim.state.scenario
+    const scenario = scenarioId
+      ? SCENARIOS.find((candidate) => candidate.id === scenarioId)
       : undefined
     const beats = scenario?.beats ?? []
     const beatIndex = beats.findIndex(
@@ -511,8 +534,8 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
     return scenario && beatIndex >= 0 ? { scenario, beats, beatIndex } : null
   }
 
-  const currentScenario = () => !traceActive && sim.state.scenario
-    ? SCENARIOS.find((candidate) => candidate.id === sim.state.scenario)
+  const currentScenario = () => !traceActive && (scenarioNotes[noteIndex]?.scenario ?? sim.state.scenario)
+    ? SCENARIOS.find((candidate) => candidate.id === (scenarioNotes[noteIndex]?.scenario ?? sim.state.scenario))
     : undefined
 
   createCorrectionPath(narrateCard, {
@@ -549,7 +572,7 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
       if (scenario) {
         return [
           ['Scenario', scenario.id],
-          ['Scenario time', `${sim.state.scenarioT.toFixed(1)} model s`],
+          ['Scenario time', `${(scenarioNotes[noteIndex]?.time ?? sim.state.scenarioT).toFixed(1)} model s`],
         ]
       }
       const table = TABLES[sim.state.trace.table]?.id ?? 'none'
@@ -697,7 +720,6 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
     traceAwaiting = true
     paintedTraceStop = null
     selectedTraceStop = null
-    narrateUntil = 0
     dismissTracePicker()
     hideNarrate(true)
     setClass(narrateCard, 'is-trace', true)
@@ -758,7 +780,6 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
   function hideNarrate(instant = false): void {
     window.clearTimeout(narrateTimer)
     narrateTimer = 0
-    narrateUntil = 0
     delete narrateBody.dataset.disclosure
     delete traceHint.dataset.disclosure
     document.body.classList.remove('pg-narrating')
@@ -766,44 +787,59 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
     if (instant) {
       setClass(narrateCard, 'is-live', false)
       setClass(narrateCard, 'is-out', false)
+      noteHistory.hidden = scenarioNotes.length === 0
       return
     }
     setClass(narrateCard, 'is-out', true)
     narrateTimer = window.setTimeout(() => {
       setClass(narrateCard, 'is-live', false)
       setClass(narrateCard, 'is-out', false)
+      noteHistory.hidden = scenarioNotes.length === 0
     }, 260)
   }
 
-  function showNarrate(title: string, body: string, seconds: number): void {
+  function paintNoteControls(): void {
+    notePrevious.disabled = noteIndex <= 0
+    noteNext.disabled = noteIndex + 1 >= scenarioNotes.length
+    setText(noteNext, noteNext.disabled ? 'Next note' : `Next note · ${scenarioNotes.length - noteIndex - 1} later`)
+    const note = scenarioNotes[noteIndex]
+    if (note) setText(narrateEyebrow, `Scenario notes · ${noteIndex + 1} / ${scenarioNotes.length} · ${note.time.toFixed(0)} model s`)
+    setText(noteHistory, `Scenario notes · ${scenarioNotes.length}`)
+  }
+
+  function paintScenarioNote(): void {
+    const note = scenarioNotes[noteIndex]
+    if (!note || traceActive || running) return
+    window.clearTimeout(narrateTimer)
+    setClass(narrateCard, 'is-trace', false)
+    document.body.classList.add('pg-narrating')
+    setText(narrateTitle, note.title)
+    setText(narrateBody, note.body)
+    narrateBody.scrollTop = 0
+    delete traceHint.dataset.disclosure
+    if (note.scenario === 'work-mem-spill') narrateBody.dataset.disclosure = 'work-mem-scenario-narration'
+    else if (note.scenario === 'connection-storm') narrateBody.dataset.disclosure = 'connection-pooler-scenario-narration'
+    else delete narrateBody.dataset.disclosure
+    setClass(narrateCard, 'is-out', false)
+    setClass(narrateCard, 'is-live', true)
+    noteHistory.hidden = true
+    paintNoteControls()
+  }
+
+  function showNarrate(title: string, body: string): void {
     if (traceActive) return
     // Never two cards in the same corner. A scenario beat only happens because
     // somebody started a scenario, and starting one answers the invitation's
     // question — so the invitation stands down rather than stacking on top of
     // the narration that the viewer actually asked for.
     if (firstLive) hideFirstRun()
-    window.clearTimeout(narrateTimer)
-    setClass(narrateCard, 'is-trace', false)
-    document.body.classList.add('pg-narrating')
-    setText(narrateEyebrow, 'Scenario')
-    setText(narrateTitle, title)
-    setText(narrateBody, body)
-    delete traceHint.dataset.disclosure
-    if (sim.state.scenario === 'work-mem-spill') {
-      narrateBody.dataset.disclosure = 'work-mem-scenario-narration'
-    } else if (sim.state.scenario === 'connection-storm') {
-      narrateBody.dataset.disclosure = 'connection-pooler-scenario-narration'
-    } else {
-      delete narrateBody.dataset.disclosure
-    }
-    setClass(narrateCard, 'is-out', false)
-    if (!narrateCard.classList.contains('is-live')) {
-      narrateCard.classList.remove('is-enter')
-      void narrateCard.offsetWidth
-      narrateCard.classList.add('is-enter')
-    }
-    setClass(narrateCard, 'is-live', true)
-    narrateUntil = sim.state.scenarioT + Math.max(1.2, seconds)
+    // A bounded, attempt-local notebook keeps the full explanation; newer
+    // beats queue rather than replacing the paragraph the reader is reading.
+    if (scenarioNotes.length === 64) return
+    scenarioNotes.push({ title, body, scenario: sim.state.scenario, time: sim.state.scenarioT })
+    if (noteIndex < 0) noteIndex = 0
+    if (!notesDismissed && !narrateCard.classList.contains('is-live')) paintScenarioNote()
+    else paintNoteControls()
   }
 
   /* =======================================================================
@@ -883,7 +919,7 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
     if (!options.onInvestigate) firstTimer = window.setTimeout(() => hideFirstRun(), FIRST_RUN_LIFE_MS)
   }
 
-  layer.append(firstRun, narrateCard, card)
+  layer.append(firstRun, narrateCard, noteHistory, card)
 
   showFirstRun()
 
@@ -1093,7 +1129,22 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
         hideNarrate()
         return
       }
-      showNarrate(p.title, p.body, p.seconds ?? SCENARIO_NARRATION_SECONDS)
+      showNarrate(p.title, p.body)
+    }),
+    bus.on('scenario', ({ id }) => {
+      if (!id) return
+      scenarioNotes.length = 0
+      noteIndex = -1
+      notesDismissed = false
+      hideNarrate(true)
+      noteHistory.hidden = true
+    }),
+    bus.on('sim:reset', () => {
+      scenarioNotes.length = 0
+      noteIndex = -1
+      notesDismissed = false
+      hideNarrate(true)
+      noteHistory.hidden = true
     }),
     bus.on('camera:mode', () => {
       if (running) userControl = true
@@ -1137,7 +1188,6 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
 
   function update(dt: number, wallDt = dt): void {
     updateTrace(dt, wallDt)
-    if (narrateUntil > 0 && sim.state.scenarioT >= narrateUntil) hideNarrate()
     if (!running) return
 
     const step = STEPS[index]
@@ -1191,6 +1241,7 @@ export function createTour(ctx: UiContext, options: TourOptions = {}): UiModule 
     document.body.classList.remove('pg-narrating')
     card.remove()
     narrateCard.remove()
+    noteHistory.remove()
     firstRun.remove()
     tracePicker.remove()
   }

--- a/src/ui/vacuum-lesson-state.test.ts
+++ b/src/ui/vacuum-lesson-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectVacuumEvidence,
+  createVacuumLessonState,
+  canChooseVacuumAction,
+  chooseVacuumAction,
+  selectVacuumCause,
+  verifyVacuumRecovery,
+  VACUUM_EVIDENCE,
+  type VacuumReading,
+} from './vacuum-lesson-state'
+
+const reading: VacuumReading = {
+  time: 60, deadRows: 900, initialDeadRows: 100,
+  pages: 120, initialPages: 100, scanObserved: true,
+  snapshotAge: 58, horizon: 400, pinned: true,
+  decisionReady: true, reclaimed: 0, recovered: false,
+}
+
+function investigated() {
+  let state = createVacuumLessonState('challenge')
+  for (const id of VACUUM_EVIDENCE) state = collectVacuumEvidence(state, id, reading, `${id} evidence`)
+  return selectVacuumCause(state, 'snapshot')
+}
+
+describe('vacuum investigation evidence and recovery', () => {
+  it('requires all four evidence sources and a supported explanation before intervention', () => {
+    let state = createVacuumLessonState('guided')
+    for (const id of ['table', 'worker', 'snapshot'] as const) {
+      state = collectVacuumEvidence(state, id, reading, id)
+    }
+    state = selectVacuumCause(state, 'snapshot')
+    expect(canChooseVacuumAction(state, reading)).toBe(false)
+    expect(chooseVacuumAction(state, 'terminate', reading)).toBe(state)
+    state = collectVacuumEvidence(state, 'owner', reading, 'Authored owner confirmation')
+    expect(canChooseVacuumAction(state, reading)).toBe(true)
+  })
+
+  it('does not accept observations that have not happened', () => {
+    const state = createVacuumLessonState('challenge')
+    const quiet = { ...reading, deadRows: 100, scanObserved: false, pinned: false }
+    for (const id of VACUUM_EVIDENCE) expect(collectVacuumEvidence(state, id, quiet, id)).toBe(state)
+  })
+
+  it('requires model readiness even after all the evidence is collected', () => {
+    expect(canChooseVacuumAction(investigated(), { ...reading, decisionReady: false })).toBe(false)
+  })
+
+  it('keeps the captured evidence and timestamp when live values change', () => {
+    const state = collectVacuumEvidence(createVacuumLessonState('guided'), 'table', reading, '900 old versions')
+    const next = collectVacuumEvidence(state, 'table', { ...reading, time: 80, deadRows: 1500 }, '1500 old versions')
+    expect(next.evidence.table).toEqual({ time: 60, text: '900 old versions' })
+    expect(state.evidence.table).toEqual(next.evidence.table)
+  })
+
+  it('does not treat an incorrect hypothesis as a diagnosis', () => {
+    const state = selectVacuumCause(investigated(), 'disabled')
+    expect(canChooseVacuumAction(state, reading)).toBe(false)
+    expect(state.cause).toBe('disabled')
+  })
+
+  it('does not pronounce recovery when only the snapshot has gone', () => {
+    const state = chooseVacuumAction(investigated(), 'terminate', reading)
+    expect(state.phase).toBe('observing')
+    expect(verifyVacuumRecovery(state, { ...reading, pinned: false })).toBe(state)
+    expect(verifyVacuumRecovery(state, { ...reading, pinned: false, recovered: true })).toBe(state)
+    expect(verifyVacuumRecovery(state, { ...reading, reclaimed: 20, recovered: true })).toBe(state)
+  })
+
+  it('verifies resumed cleanup from a model recovery and positive collection', () => {
+    const state = chooseVacuumAction(investigated(), 'terminate', reading)
+    const recovered = { ...reading, pinned: false, reclaimed: 20, recovered: true }
+    expect(verifyVacuumRecovery(state, recovered).phase).toBe('complete')
+    expect(verifyVacuumRecovery(investigated(), recovered).phase).toBe('investigating')
+  })
+
+  it('can verify recovery after waiting and subsequently releasing the transaction', () => {
+    const state = chooseVacuumAction(investigated(), 'wait', reading)
+    expect(verifyVacuumRecovery(state, reading).phase).toBe('observing')
+    expect(verifyVacuumRecovery(state, { ...reading, pinned: false, reclaimed: 20, recovered: true }).phase)
+      .toBe('complete')
+  })
+})

--- a/src/ui/vacuum-lesson-state.ts
+++ b/src/ui/vacuum-lesson-state.ts
@@ -1,0 +1,77 @@
+export const VACUUM_EVIDENCE = ['table', 'worker', 'snapshot', 'owner'] as const
+export type VacuumEvidenceId = typeof VACUUM_EVIDENCE[number]
+export type VacuumLessonMode = 'guided' | 'challenge'
+export type VacuumCause = 'disabled' | 'snapshot' | 'capacity'
+export type VacuumAction = 'terminate' | 'wait'
+
+export interface VacuumReading {
+  time: number
+  deadRows: number
+  initialDeadRows: number
+  pages: number
+  initialPages: number
+  scanObserved: boolean
+  snapshotAge: number
+  horizon: number
+  pinned: boolean
+  decisionReady: boolean
+  reclaimed: number
+  recovered: boolean
+}
+
+export interface VacuumLessonState {
+  mode: VacuumLessonMode
+  phase: 'investigating' | 'observing' | 'complete'
+  evidence: Partial<Record<VacuumEvidenceId, { time: number; text: string }>>
+  cause: VacuumCause | null
+  action: VacuumAction | null
+}
+
+export function createVacuumLessonState(mode: VacuumLessonMode): VacuumLessonState {
+  return { mode, phase: 'investigating', evidence: {}, cause: null, action: null }
+}
+
+export function vacuumEvidenceAvailable(id: VacuumEvidenceId, reading: VacuumReading): boolean {
+  switch (id) {
+    case 'table': return reading.deadRows > reading.initialDeadRows
+    case 'worker': return reading.scanObserved
+    case 'snapshot': return reading.pinned && reading.snapshotAge > 0
+    case 'owner': return reading.pinned && reading.snapshotAge > 0
+  }
+}
+
+export function collectVacuumEvidence(
+  state: VacuumLessonState,
+  id: VacuumEvidenceId,
+  reading: VacuumReading,
+  text: string,
+): VacuumLessonState {
+  if (state.phase !== 'investigating' || state.evidence[id] || !vacuumEvidenceAvailable(id, reading)) return state
+  return { ...state, evidence: { ...state.evidence, [id]: { time: reading.time, text } } }
+}
+
+export function selectVacuumCause(state: VacuumLessonState, cause: VacuumCause): VacuumLessonState {
+  if (state.phase !== 'investigating') return state
+  return { ...state, cause }
+}
+
+export function canChooseVacuumAction(state: VacuumLessonState, reading: VacuumReading): boolean {
+  return state.phase === 'investigating'
+    && state.cause === 'snapshot'
+    && VACUUM_EVIDENCE.every((id) => state.evidence[id])
+    && reading.decisionReady
+}
+
+export function chooseVacuumAction(
+  state: VacuumLessonState,
+  action: VacuumAction,
+  reading: VacuumReading,
+): VacuumLessonState {
+  if (!canChooseVacuumAction(state, reading)) return state
+  return { ...state, phase: 'observing', action }
+}
+
+export function verifyVacuumRecovery(state: VacuumLessonState, reading: VacuumReading): VacuumLessonState {
+  if (state.phase !== 'observing' || reading.pinned || !reading.recovered || reading.reclaimed <= 0) return state
+  return { ...state, phase: 'complete' }
+}

--- a/src/ui/vacuum-lesson.test.ts
+++ b/src/ui/vacuum-lesson.test.ts
@@ -66,6 +66,21 @@ describe('vacuum lesson in the live model', () => {
     expect(document.querySelector('[data-disclosure="vacuum-model"]')!.textContent).toContain('City model')
   })
 
+  it('positions its desktop panel below the measured wrapped toolbar', () => {
+    const f = fixture()
+    const hud = document.createElement('div')
+    hud.id = 'hud-top'
+    hud.getBoundingClientRect = () => ({ bottom: 138 }) as DOMRect
+    document.body.append(hud)
+    f.lesson.open()
+    const panel = document.querySelector<HTMLElement>('.vacuum-lesson')!
+    const style = panel.style as unknown as Record<string, string>
+    expect(style['--vacuum-top']).toBe('150px')
+    hud.getBoundingClientRect = () => ({ bottom: 182 }) as DOMRect
+    window.dispatchEvent(new Event('resize'))
+    expect(style['--vacuum-top']).toBe('194px')
+  })
+
   it('requires evidence, then waits for real cleanup and an explicit recovery check', () => {
     const f = fixture()
     f.lesson.open('challenge')

--- a/src/ui/vacuum-lesson.test.ts
+++ b/src/ui/vacuum-lesson.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createBus } from '../core/bus'
+import { createSim } from '../sim/model'
+import { installTestDom } from '../../test/dom'
+import { createVacuumLesson, type VacuumLessonModule, type VacuumLessonOptions, type VacuumLessonProgress } from './vacuum-lesson'
+import { VACUUM_EVIDENCE } from './vacuum-lesson-state'
+import type { UiContext } from './uikit'
+
+const modules: VacuumLessonModule[] = []
+
+function fixture(level: 'high' | 'reduced' = 'high', options: VacuumLessonOptions = {}) {
+  installTestDom()
+  const bus = createBus()
+  const sim = createSim(bus, { maxStep: 1 / 3, scheduledBackups: false })
+  const ctx = {
+    bus, sim, registry: { get: () => undefined },
+    getFps: () => 60,
+    getQuality: () => ({ level }),
+    getFlowStats: () => ({ active: 0, dropped: 0 }),
+  } as unknown as UiContext
+  const lesson = createVacuumLesson(ctx, options)
+  modules.push(lesson)
+  return { sim, bus, lesson }
+}
+
+function button(selector: string): HTMLButtonElement {
+  return document.querySelector<HTMLButtonElement>(selector)!
+}
+
+function advanceUntil(
+  f: ReturnType<typeof fixture>,
+  done: () => boolean,
+  limit = 900,
+): void {
+  const end = f.sim.state.t + limit
+  while (!done() && f.sim.state.t < end) {
+    f.sim.update(1 / 3)
+    f.lesson.update(1 / 3)
+  }
+  expect(done()).toBe(true)
+}
+
+function investigate(f: ReturnType<typeof fixture>): void {
+  advanceUntil(f, () => f.sim.state.scenarioDecision?.phase === 'ready')
+  for (const id of VACUUM_EVIDENCE) {
+    button(`[data-vacuum-evidence="${id}"]`).click()
+    expect(button('[data-vacuum-record]').disabled).toBe(false)
+    button('[data-vacuum-record]').click()
+  }
+  button('[data-vacuum-cause="snapshot"]').click()
+}
+
+afterEach(() => {
+  while (modules.length) modules.pop()!.dispose()
+})
+
+describe('vacuum lesson in the live model', () => {
+  it('requires evidence, then waits for real cleanup and an explicit recovery check', () => {
+    const f = fixture()
+    f.lesson.open('challenge')
+    expect(f.sim.state.scenario).toBe('vacuum-blockade')
+    expect(button('[data-vacuum-action="terminate"]').disabled).toBe(true)
+    button('[data-vacuum-action="terminate"]').click()
+    expect(f.sim.state.knobs.longRunningXact).toBe(true)
+    investigate(f)
+    expect(document.querySelector('[data-vacuum-notebook]')!.textContent).toContain('Authored scenario context')
+    expect(button('[data-vacuum-action="terminate"]').disabled).toBe(false)
+    button('[data-vacuum-action="terminate"]').click()
+    expect(f.sim.state.knobs.longRunningXact).toBe(false)
+    expect(document.querySelector<HTMLElement>('.vacuum-lesson')!.dataset.phase).toBe('observing')
+    button('[data-vacuum-verify]').click()
+    expect(document.querySelector<HTMLElement>('.vacuum-lesson')!.dataset.phase).toBe('observing')
+    advanceUntil(f, () => f.sim.state.scenarioDecision?.phase === 'recovered')
+    expect(document.querySelector<HTMLElement>('.vacuum-lesson')!.dataset.phase).toBe('observing')
+    button('[data-vacuum-verify]').click()
+    expect(document.querySelector<HTMLElement>('.vacuum-lesson')!.dataset.phase).toBe('complete')
+    expect(document.querySelector('[data-vacuum-result]')!.textContent).toMatch(/cleanup has resumed/i)
+    expect(document.querySelector('[data-disclosure="vacuum-model"]')!.textContent).toMatch(/sampled|representative/)
+  })
+
+  it('retains the notebook and personal notes while inspecting a representative page', () => {
+    const f = fixture()
+    const opens: string[] = []
+    f.bus.on('anatomy:open', ({ id }) => opens.push(id ?? ''))
+    f.lesson.open()
+    investigate(f)
+    const notebook = document.querySelector('[data-vacuum-notebook]')!.textContent
+    const notes = document.querySelector<HTMLTextAreaElement>('[data-vacuum-notes]')!
+    notes.value = 'Check the snapshot before tuning vacuum.'
+    button('[data-vacuum-page]').click()
+    f.lesson.update(3600)
+    expect(opens).toEqual(['storage.table.sessions'])
+    expect(document.querySelector('[data-vacuum-notebook]')!.textContent).toBe(notebook)
+    expect(notes.value).toBe('Check the snapshot before tuning vacuum.')
+    expect(f.lesson.isOpen()).toBe(true)
+  })
+
+  it('lets a learner observe waiting, release the transaction, and verify recovery', () => {
+    const f = fixture()
+    f.lesson.open()
+    investigate(f)
+    button('[data-vacuum-action="wait"]').click()
+    expect(f.sim.state.knobs.longRunningXact).toBe(true)
+    button('[data-vacuum-recover]').click()
+    expect(f.sim.state.knobs.longRunningXact).toBe(false)
+    advanceUntil(f, () => f.sim.state.scenarioDecision?.phase === 'recovered')
+    button('[data-vacuum-verify]').click()
+    expect(document.querySelector<HTMLElement>('.vacuum-lesson')!.dataset.phase).toBe('complete')
+  })
+
+  it('restores its own knobs and focus on close without resetting relation history', () => {
+    const f = fixture()
+    f.sim.setKnob('tps', 321)
+    f.sim.setKnob('timeScale', 0.5)
+    f.sim.setKnob('paused', true)
+    const opener = document.createElement('button')
+    document.body.append(opener)
+    opener.focus()
+    f.lesson.open()
+    advanceUntil(f, () => f.sim.state.scenarioT > 2)
+    const time = f.sim.state.t
+    f.lesson.close()
+    expect(f.sim.state.scenario).toBeNull()
+    expect(f.sim.state.knobs.tps).toBe(321)
+    expect(f.sim.state.knobs.timeScale).toBe(0.5)
+    expect(f.sim.state.knobs.paused).toBe(true)
+    expect(f.sim.state.t).toBe(time)
+    expect(document.activeElement).toBe(opener)
+    expect(document.body.classList.contains('pg-vacuum-lesson')).toBe(false)
+  })
+
+  it('does not end a replacement scenario or restore pre-lesson settings over a reset', () => {
+    const f = fixture()
+    f.sim.setKnob('timeScale', 0.5)
+    f.lesson.open()
+    f.sim.runScenario('bloat-and-vacuum')
+    expect(f.lesson.isOpen()).toBe(false)
+    expect(f.sim.state.scenario).toBe('bloat-and-vacuum')
+    f.lesson.open()
+    f.sim.reset()
+    expect(f.lesson.isOpen()).toBe(false)
+    expect(f.sim.state.scenario).toBeNull()
+    expect(f.sim.state.knobs.timeScale).toBe(1)
+  })
+
+  it('does not undo a time control the reader changed outside the lesson', () => {
+    const f = fixture()
+    f.sim.setKnob('timeScale', 0.5)
+    f.lesson.open()
+    f.sim.setKnob('timeScale', 2, 'user')
+    f.lesson.close()
+    expect(f.sim.state.knobs.timeScale).toBe(2)
+  })
+
+  it('keeps a reduced-motion city paused and changes focus instantly', () => {
+    const f = fixture('reduced')
+    const focuses: { id: string | null; instant?: boolean }[] = []
+    f.bus.on('focus', (event) => focuses.push(event))
+    f.sim.setKnob('paused', true)
+    f.lesson.open()
+    expect(f.sim.state.knobs.paused).toBe(true)
+    expect(focuses.at(-1)).toEqual({ id: 'storage.table.sessions', instant: true })
+    button('[data-vacuum-pause]').click()
+    expect(f.sim.state.knobs.paused).toBe(false)
+    f.lesson.close()
+    expect(f.sim.state.knobs.paused).toBe(true)
+  })
+
+  it('reports only fixed progress events and mode, with completion gated by actual cleanup', () => {
+    const events: VacuumLessonProgress[] = []
+    const f = fixture('high', { onProgress: (progress) => events.push(progress) })
+    f.lesson.open('challenge')
+    investigate(f)
+    button('[data-vacuum-hint]').click()
+    button('[data-vacuum-action="terminate"]').click()
+    button('[data-vacuum-verify]').click()
+    expect(events).toEqual([
+      { event: 'started', mode: 'challenge' },
+      ...VACUUM_EVIDENCE.map(() => ({ event: 'evidence-collected', mode: 'challenge' })),
+      { event: 'hint-used', mode: 'challenge' },
+    ])
+    advanceUntil(f, () => f.sim.state.scenarioDecision?.phase === 'recovered')
+    button('[data-vacuum-verify]').click()
+    expect(events.at(-1)).toEqual({ event: 'recovery-verified', mode: 'guided' })
+    expect(events.every((event) => Object.keys(event).sort().join(',') === 'event,mode')).toBe(true)
+  })
+
+  it('keeps the lesson usable when an optional analytics callback fails', () => {
+    const f = fixture('high', { onProgress: () => { throw new Error('Analytics unavailable') } })
+    expect(() => f.lesson.open()).not.toThrow()
+    expect(f.lesson.isOpen()).toBe(true)
+    expect(f.sim.state.scenario).toBe('vacuum-blockade')
+  })
+})

--- a/src/ui/vacuum-lesson.test.ts
+++ b/src/ui/vacuum-lesson.test.ts
@@ -55,6 +55,17 @@ afterEach(() => {
 })
 
 describe('vacuum lesson in the live model', () => {
+  it('only exposes lesson claims and disclosures while their panel is open', () => {
+    const f = fixture()
+    expect(document.querySelector('[data-disclosure="vacuum-model"]')).toBeNull()
+    f.lesson.open()
+    expect(document.querySelector('[data-disclosure="vacuum-model"]')!.textContent).toContain('City model')
+    f.lesson.close()
+    expect(document.querySelector('[data-disclosure="vacuum-model"]')).toBeNull()
+    f.lesson.open()
+    expect(document.querySelector('[data-disclosure="vacuum-model"]')!.textContent).toContain('City model')
+  })
+
   it('requires evidence, then waits for real cleanup and an explicit recovery check', () => {
     const f = fixture()
     f.lesson.open('challenge')

--- a/src/ui/vacuum-lesson.ts
+++ b/src/ui/vacuum-lesson.ts
@@ -217,6 +217,16 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
     retry, disclosure),
   )
 
+  function positionPanel(): void {
+    if (!opened) return
+    const bottom = document.getElementById('hud-top')?.getBoundingClientRect().bottom ?? 0
+    panel.style.setProperty('--vacuum-top', `${Math.max(78, Math.ceil(bottom) + 12)}px`)
+  }
+  const toolbar = document.getElementById('hud-top')
+  const toolbarObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(positionPanel)
+  if (toolbar) toolbarObserver?.observe(toolbar)
+  window.addEventListener('resize', positionPanel)
+
   function announce(text: string): void { setText(announcement, text) }
 
   function progress(event: VacuumLessonProgress['event']): void {
@@ -390,6 +400,7 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
     opened = true
     document.body.append(panel)
     panel.hidden = false
+    positionPanel()
     document.body.classList.add('pg-vacuum-lesson')
     state = createVacuumLessonState(mode)
     selected = 'table'
@@ -464,6 +475,8 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
       refresh()
     },
     dispose() {
+      toolbarObserver?.disconnect()
+      window.removeEventListener('resize', positionPanel)
       for (const unsubscribe of off) unsubscribe()
       close()
       panel.remove()

--- a/src/ui/vacuum-lesson.ts
+++ b/src/ui/vacuum-lesson.ts
@@ -216,7 +216,6 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
       el('p', { text: 'Evidence and notes stay here until you start another attempt.' })),
     retry, disclosure),
   )
-  document.body.append(panel)
 
   function announce(text: string): void { setText(announcement, text) }
 
@@ -389,6 +388,7 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
     ctx.bus.emit('narrate', null)
     restorePaused = restoreTimeScale = true
     opened = true
+    document.body.append(panel)
     panel.hidden = false
     document.body.classList.add('pg-vacuum-lesson')
     state = createVacuumLessonState(mode)
@@ -418,6 +418,7 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
     if (!opened) return
     opened = false
     panel.hidden = true
+    panel.remove()
     document.body.classList.remove('pg-vacuum-lesson')
     if (stopScenario && ctx.sim.state.scenarioDecision === ownedDecision && ctx.sim.state.scenario === 'vacuum-blockade') ctx.sim.runScenario(null)
     ownedDecision = null

--- a/src/ui/vacuum-lesson.ts
+++ b/src/ui/vacuum-lesson.ts
@@ -1,6 +1,7 @@
 import '../styles/vacuum-lesson.css'
 
 import type { SimState } from '../core/types'
+import { lessonShareUrl } from '../core/lesson-route'
 import { fmtBytes, fmtNum, reduceMotion } from '../core/util'
 import {
   canChooseVacuumAction, chooseVacuumAction, collectVacuumEvidence,
@@ -176,6 +177,25 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
     type: 'button', class: 'pg-btn', text: 'Start another attempt', data: { vacuumRetry: '' },
     on: { click: () => { const mode = state.mode; close(); open(mode) } },
   })
+  const challengeButton = el('button', {
+    type: 'button', class: 'pg-btn', text: 'Start a challenge attempt',
+    on: { click: () => { close(); open('challenge') } },
+  })
+  const shareButton = el('button', {
+    type: 'button', class: 'pg-btn', text: 'Share this lesson',
+    on: { click: async () => {
+      const url = lessonShareUrl(window.location.href, state.mode)
+      try {
+        await navigator.clipboard.writeText(url)
+        announce('Lesson link copied. It opens a new attempt in this mode; notes and current model state are not included.')
+      } catch {
+        shareLink.href = url
+        shareLink.hidden = false
+        announce('Clipboard unavailable. Copy the lesson link below; it does not include your notes or current model state.')
+      }
+    } },
+  })
+  const shareLink = el('a', { class: 'pg-btn', text: 'Open a new attempt', hidden: true })
   const retry = el('div', { class: 'vacuum-lesson__retry' }, retryButton,
     el('p', { text: 'A new attempt uses the city’s current state and clears this notebook. It does not rewind the previous workload.' }),
   )
@@ -190,7 +210,7 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
     el('div', { class: 'vacuum-lesson__meta' }, modeLabel, clock), closeButton, title, phaseLabel),
   el('div', { class: 'vacuum-lesson__body' },
     evidenceNav, evidenceDetail, causes, decision, observation, announcement,
-    el('div', { class: 'vacuum-lesson__tools' }, pageButton, pauseButton, hintButton),
+    el('div', { class: 'vacuum-lesson__tools' }, pageButton, pauseButton, hintButton, challengeButton, shareButton, shareLink),
     el('details', { class: 'vacuum-lesson__notes' }, notebookSummary, notebook,
       el('label', { htmlFor: 'vacuum-personal-notes', text: 'Your notes' }), notes,
       el('p', { text: 'Evidence and notes stay here until you start another attempt.' })),
@@ -352,6 +372,7 @@ export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions 
     setText(pauseButton, ctx.sim.state.knobs.paused ? 'Run model' : 'Pause model')
     pauseButton.setAttribute('aria-pressed', String(ctx.sim.state.knobs.paused))
     hintButton.hidden = state.mode === 'guided' || state.phase !== 'investigating'
+    challengeButton.hidden = state.mode === 'challenge'
     retry.hidden = state.phase === 'investigating'
   }
 

--- a/src/ui/vacuum-lesson.ts
+++ b/src/ui/vacuum-lesson.ts
@@ -1,0 +1,450 @@
+import '../styles/vacuum-lesson.css'
+
+import type { SimState } from '../core/types'
+import { fmtBytes, fmtNum, reduceMotion } from '../core/util'
+import {
+  canChooseVacuumAction, chooseVacuumAction, collectVacuumEvidence,
+  createVacuumLessonState, selectVacuumCause, vacuumEvidenceAvailable,
+  verifyVacuumRecovery, VACUUM_EVIDENCE,
+  type VacuumAction, type VacuumCause, type VacuumEvidenceId,
+  type VacuumLessonMode, type VacuumReading,
+} from './vacuum-lesson-state'
+import { el, setText } from './uikit'
+import type { UiContext, UiModule } from './uikit'
+
+export interface VacuumLessonModule extends UiModule {
+  open(mode?: VacuumLessonMode): void
+  close(): void
+  isOpen(): boolean
+}
+
+export interface VacuumLessonProgress {
+  event: 'started' | 'hint-used' | 'evidence-collected' | 'recovery-verified'
+  mode: VacuumLessonMode
+}
+
+export interface VacuumLessonOptions {
+  onProgress?: (progress: VacuumLessonProgress) => void
+}
+
+const TABLE = 'storage.table.sessions'
+const EVIDENCE_COPY: Record<VacuumEvidenceId, { title: string; source: string; guidance: string; focus: string }> = {
+  table: {
+    title: 'Table health', source: 'Live model · pg_stat_user_tables vocabulary', focus: TABLE,
+    guidance: 'Compare old row versions with the start of this attempt. A rising count tells you cleanup is falling behind; it does not tell you why.',
+  },
+  worker: {
+    title: 'Vacuum work', source: 'Observed model worker · pg_stat_progress_vacuum vocabulary', focus: 'autovac.launcher',
+    guidance: 'A worker can scan a table while old versions remain. Running and successfully reclaiming space are different observations.',
+  },
+  snapshot: {
+    title: 'Open transactions', source: 'Live model · transaction and snapshot state', focus: 'proc.array',
+    guidance: 'This REPEATABLE READ transaction retains an old snapshot. Compare it with the cleanup horizon: versions it might still need must remain.',
+  },
+  owner: {
+    title: 'Owner’s incident note', source: 'Authored scenario context · not a database measurement', focus: 'proc.array',
+    guidance: 'An old transaction is not automatically safe to terminate. Confirm the session, its owner and the consequences of aborting its work.',
+  },
+}
+
+export function createVacuumLesson(ctx: UiContext, options: VacuumLessonOptions = {}): VacuumLessonModule {
+  let opened = false
+  let changingScenario = false
+  let changingTiming = false
+  let ownedDecision: SimState['scenarioDecision'] = null
+  let state = createVacuumLessonState('guided')
+  let selected: VacuumEvidenceId = 'table'
+  let lastFocus: HTMLElement | null = null
+  let savedPaused = false
+  let savedTimeScale = 1
+  let restorePaused = false
+  let restoreTimeScale = false
+  let refreshIn = 0
+  let observedWorker = ''
+  let observedWorkerSlot = -1
+  let tableIndex = 0
+  const reading: VacuumReading = {
+    time: 0, deadRows: 0, initialDeadRows: 0, pages: 0, initialPages: 0,
+    scanObserved: false, snapshotAge: 0, horizon: 0, pinned: false,
+    decisionReady: false, reclaimed: 0, recovered: false,
+  }
+
+  const title = el('h2', { id: 'vacuum-lesson-title', tabindex: '-1', text: 'Autovacuum is running. Why is this table still growing?' })
+  const modeLabel = el('span', { class: 'vacuum-lesson__mode' })
+  const clock = el('span', { class: 'vacuum-lesson__clock' })
+  const phaseLabel = el('p', { class: 'vacuum-lesson__step' })
+  const closeButton = el('button', {
+    type: 'button', class: 'pg-btn vacuum-lesson__close', text: 'Exit',
+    'aria-label': 'Exit the vacuum investigation', on: { click: () => close() },
+  })
+  const evidenceTitle = el('h3', { id: 'vacuum-evidence-title' })
+  const evidenceSource = el('p', { class: 'vacuum-lesson__source' })
+  const evidenceReading = el('p', { class: 'vacuum-lesson__reading' })
+  const guidance = el('p', { class: 'vacuum-lesson__guidance' })
+  const announcement = el('p', { class: 'vacuum-lesson__announcement', role: 'status', 'aria-live': 'polite' })
+  const notebook = el('ol', { class: 'vacuum-lesson__notebook', data: { vacuumNotebook: '' } })
+  const notebookSummary = el('summary', { text: 'Evidence notebook · 0 of 4' })
+  const notes = el('textarea', {
+    id: 'vacuum-personal-notes', rows: 3, maxlength: 4000,
+    placeholder: 'Your explanation, questions or next checks…', data: { vacuumNotes: '' },
+  })
+  const recordButton = el('button', {
+    type: 'button', class: 'pg-btn vacuum-lesson__primary', data: { vacuumRecord: '' },
+    on: { click: recordEvidence },
+  })
+  const evidenceButtons = new Map<VacuumEvidenceId, HTMLButtonElement>()
+  const evidenceNav = el('nav', { class: 'vacuum-lesson__evidence', 'aria-label': 'Investigation evidence' })
+  for (const id of VACUUM_EVIDENCE) {
+    const button = el('button', {
+      type: 'button', class: 'vacuum-lesson__evidence-button',
+      text: EVIDENCE_COPY[id].title, data: { vacuumEvidence: id },
+      'aria-controls': 'vacuum-evidence-detail', 'aria-pressed': 'false',
+      on: { click: () => inspect(id) },
+    })
+    evidenceButtons.set(id, button)
+    evidenceNav.append(button)
+  }
+  const evidenceDetail = el('section', {
+    id: 'vacuum-evidence-detail', class: 'vacuum-lesson__detail', 'aria-labelledby': 'vacuum-evidence-title',
+  }, evidenceSource, evidenceTitle, evidenceReading, guidance, recordButton)
+
+  const causeFeedback = el('p', { class: 'vacuum-lesson__feedback' })
+  const causes = el('section', { class: 'vacuum-lesson__causes' },
+    el('h3', { text: 'What is preventing cleanup?' }),
+  )
+  const causeButtons = new Map<VacuumCause, HTMLButtonElement>()
+  for (const [cause, text] of [
+    ['disabled', 'Autovacuum is switched off'],
+    ['snapshot', 'An older snapshot still needs the row versions'],
+    ['capacity', 'The table only needs more disk capacity'],
+  ] as const) {
+    const button = el('button', {
+      type: 'button', class: 'pg-btn vacuum-lesson__answer', text,
+      data: { vacuumCause: cause }, 'aria-pressed': 'false',
+      on: { click: () => { state = selectVacuumCause(state, cause); render() } },
+    })
+    causeButtons.set(cause, button)
+    causes.append(button)
+  }
+  causes.append(causeFeedback)
+
+  const terminateButton = actionButton('terminate', 'End the abandoned session')
+  const waitButton = actionButton('wait', 'Keep the transaction open')
+  const decisionStatus = el('p', { class: 'vacuum-lesson__source' })
+  const decision = el('section', { class: 'vacuum-lesson__decision' },
+    el('h3', { text: 'Choose an intervention' }),
+    el('p', { text: 'The owner confirmed this session is abandoned. Ending it aborts its transaction; this scenario has no uncommitted row changes to preserve.' }),
+    terminateButton, waitButton, decisionStatus,
+  )
+  const result = el('p', { class: 'vacuum-lesson__result', data: { vacuumResult: '' } })
+  const recoverButton = el('button', {
+    type: 'button', class: 'pg-btn vacuum-lesson__primary', text: 'End the abandoned session now',
+    data: { vacuumRecover: '' }, on: { click: () => {
+      if (state.phase !== 'observing' || !state.evidence.owner || !ctx.sim.recoverScenario()) return
+      announce('The abandoned transaction has ended. Now verify that cleanup actually resumes.')
+      focus(TABLE)
+      refresh()
+    } },
+  })
+  const verifyButton = el('button', {
+    type: 'button', class: 'pg-btn vacuum-lesson__primary', text: 'Check whether cleanup resumed',
+    data: { vacuumVerify: '' }, on: { click: verify },
+  })
+  const observation = el('section', { class: 'vacuum-lesson__observation' },
+    el('h3', { text: 'Verify the outcome' }), result, recoverButton, verifyButton,
+  )
+  const pauseButton = el('button', {
+    type: 'button', class: 'pg-btn', data: { vacuumPause: '' }, on: { click: () => {
+      setTiming('paused', !ctx.sim.state.knobs.paused)
+      refresh()
+    } },
+  })
+  const pageButton = el('button', {
+    type: 'button', class: 'pg-btn', text: 'Inspect a page and its row versions', data: { vacuumPage: '' },
+    on: { click: () => ctx.bus.emit('anatomy:open', { view: 'page', id: TABLE }) },
+  })
+  const hintButton = el('button', {
+    type: 'button', class: 'pg-btn', text: 'Use guided explanations', data: { vacuumHint: '' },
+    on: { click: () => {
+      if (state.mode !== 'challenge' || state.phase !== 'investigating') return
+      progress('hint-used')
+      state = { ...state, mode: 'guided' }
+      render()
+    } },
+  })
+  const retryButton = el('button', {
+    type: 'button', class: 'pg-btn', text: 'Start another attempt', data: { vacuumRetry: '' },
+    on: { click: () => { const mode = state.mode; close(); open(mode) } },
+  })
+  const retry = el('div', { class: 'vacuum-lesson__retry' }, retryButton,
+    el('p', { text: 'A new attempt uses the city’s current state and clears this notebook. It does not rewind the previous workload.' }),
+  )
+  const disclosure = el('p', {
+    class: 'vacuum-lesson__disclosure', data: { disclosure: 'vacuum-model' },
+    text: 'City model, not PostgreSQL execution. Pages and row versions are representative samples; relation counts are aggregate model state. VACUUM normally makes space reusable inside the file. A smaller file is not required to verify cleanup.',
+  })
+  const panel = el('section', {
+    class: 'vacuum-lesson pg-panel', hidden: true, 'aria-labelledby': 'vacuum-lesson-title',
+  },
+  el('header', { class: 'vacuum-lesson__head' },
+    el('div', { class: 'vacuum-lesson__meta' }, modeLabel, clock), closeButton, title, phaseLabel),
+  el('div', { class: 'vacuum-lesson__body' },
+    evidenceNav, evidenceDetail, causes, decision, observation, announcement,
+    el('div', { class: 'vacuum-lesson__tools' }, pageButton, pauseButton, hintButton),
+    el('details', { class: 'vacuum-lesson__notes' }, notebookSummary, notebook,
+      el('label', { htmlFor: 'vacuum-personal-notes', text: 'Your notes' }), notes,
+      el('p', { text: 'Evidence and notes stay here until you start another attempt.' })),
+    retry, disclosure),
+  )
+  document.body.append(panel)
+
+  function announce(text: string): void { setText(announcement, text) }
+
+  function progress(event: VacuumLessonProgress['event']): void {
+    try { options.onProgress?.({ event, mode: state.mode }) } catch {
+      /* Optional aggregate analytics must never interrupt the model path. */
+    }
+  }
+
+  function focus(id: string): void {
+    ctx.bus.emit('select', { id, outlineOnly: true })
+    ctx.bus.emit('focus', { id, instant: reduceMotion() || ctx.getQuality().level === 'reduced' })
+  }
+
+  function setTiming(key: 'paused', value: boolean): void
+  function setTiming(key: 'timeScale', value: number): void
+  function setTiming(key: 'paused' | 'timeScale', value: boolean | number): void {
+    changingTiming = true
+    if (key === 'paused') ctx.sim.setKnob(key, value as boolean)
+    else ctx.sim.setKnob(key, value as number)
+    changingTiming = false
+  }
+
+  function sample(): void {
+    const sim = ctx.sim.state
+    const table = sim.tables[tableIndex]
+    reading.time = sim.scenarioT
+    reading.deadRows = table.deadTuples
+    reading.pages = table.pages
+    reading.snapshotAge = sim.oldestSnapshotAge
+    reading.horizon = sim.xminHorizon
+    reading.pinned = sim.knobs.longRunningXact
+    const current = sim.scenarioDecision
+    reading.decisionReady = current?.kind === 'vacuum-blockade' && current.phase === 'ready'
+    reading.reclaimed = current?.kind === 'vacuum-blockade' ? current.deadTuplesReclaimed : 0
+    reading.recovered = current?.kind === 'vacuum-blockade' && current.phase === 'recovered'
+    for (let i = 0; i < sim.autovac.workers.length; i++) {
+      const worker = sim.autovac.workers[i]
+      if (!worker.active || worker.phase === 'travel' || worker.phase === 'return' || worker.phase === 'idle') continue
+      reading.scanObserved = true
+      observedWorkerSlot = i
+      observedWorker = `At model ${reading.time.toFixed(1)} s, AV-${i} was in ${worker.phase} on ${sim.tables[worker.table].def.name}; ${fmtNum(worker.deadCollected)} versions collected in that pass.`
+      break
+    }
+  }
+
+  function evidenceText(id: VacuumEvidenceId): string {
+    switch (id) {
+      case 'table': return `sessions: ${fmtNum(reading.deadRows)} dead row versions (${fmtNum(reading.deadRows - reading.initialDeadRows)} added since this attempt began). Relation size: ${fmtBytes(reading.pages * 8192)}, from ${fmtBytes(reading.initialPages * 8192)}. These are exact model counts; PostgreSQL’s n_dead_tup is an estimate.`
+      case 'worker': return observedWorker || 'Waiting to observe a worker enter a vacuum phase. Let the model run, then record what the worker actually did.'
+      case 'snapshot': {
+        const backend = ctx.sim.state.backends.find((candidate) => candidate.state === 'idle_in_xact')
+        return backend && reading.pinned
+          ? `Model backend slot ${backend.slot}: idle in transaction. Oldest snapshot age: ${reading.snapshotAge.toFixed(1)} model s. Cleanup horizon: XID ${fmtNum(reading.horizon)}. This case has an old REPEATABLE READ snapshot.`
+          : 'There is no retained transaction snapshot from this case now. Watch the next vacuum pass to establish whether cleanup resumes.'
+      }
+      case 'owner': return 'Authored scenario context: the application owner checked this case’s idle session and confirmed an abandoned, read-only REPEATABLE READ transaction. The client is gone; no uncommitted row changes need preserving. Ending the session aborts that transaction. This owner confirmation is supplied by the lesson, not measured by pg_stat_activity.'
+    }
+  }
+
+  function inspect(id: VacuumEvidenceId): void {
+    selected = id
+    focus(id === 'worker' && observedWorkerSlot >= 0 ? `autovac.worker.${observedWorkerSlot}` : EVIDENCE_COPY[id].focus)
+    refresh()
+  }
+
+  function recordEvidence(): void {
+    sample()
+    const next = collectVacuumEvidence(state, selected, reading, evidenceText(selected))
+    if (next === state) return
+    state = next
+    notebook.append(el('li', {},
+      el('strong', { text: `${EVIDENCE_COPY[selected].title} · model ${reading.time.toFixed(1)} s` }),
+      el('p', { text: state.evidence[selected]!.text }),
+    ))
+    announce(`${EVIDENCE_COPY[selected].title} saved in your evidence notebook.`)
+    progress('evidence-collected')
+    render()
+  }
+
+  function actionButton(action: VacuumAction, text: string): HTMLButtonElement {
+    return el('button', {
+      type: 'button', class: 'pg-btn vacuum-lesson__answer', text, data: { vacuumAction: action },
+      on: { click: () => {
+        sample()
+        const next = chooseVacuumAction(state, action, reading)
+        if (next === state || !ctx.sim.chooseScenario(action === 'terminate' ? 'terminate-transaction' : 'wait-for-transaction')) return
+        state = next
+        announce(action === 'terminate'
+          ? 'The transaction ended. Releasing a snapshot makes cleanup possible; it does not itself reclaim the bytes.'
+          : 'You kept the transaction open. Watch the retained versions and compare the consequence with your evidence.')
+        focus(TABLE)
+        refresh()
+      } },
+    })
+  }
+
+  function verify(): void {
+    sample()
+    const next = verifyVacuumRecovery(state, reading)
+    if (next !== state) {
+      state = next
+      announce('Verified: the old snapshot is gone and a modeled vacuum pass has reclaimed row versions.')
+      progress('recovery-verified')
+    } else {
+      announce(reading.pinned
+        ? 'Not yet: the transaction still holds its old snapshot.'
+        : 'Not yet: the snapshot has ended, but the model has not reported resumed cleanup. Let the worker finish its pass.')
+    }
+    render()
+  }
+
+  function render(): void {
+    panel.dataset.phase = state.phase
+    const count = VACUUM_EVIDENCE.filter((id) => state.evidence[id]).length
+    setText(modeLabel, state.mode === 'guided' ? 'Guided investigation' : 'Challenge · evidence first')
+    setText(clock, `${reading.time.toFixed(0)} model s`)
+    setText(phaseLabel, state.phase === 'complete' ? '3 / 3 · Cleanup verified'
+      : state.phase === 'observing' ? '3 / 3 · Observe and verify'
+        : count === 4 ? '2 / 3 · Explain the evidence and act' : `1 / 3 · Investigate · ${count} of 4 evidence sources`)
+    for (const [id, button] of evidenceButtons) {
+      button.setAttribute('aria-pressed', String(id === selected))
+      button.dataset.recorded = String(!!state.evidence[id])
+      setText(button, `${state.evidence[id] ? '✓ ' : ''}${EVIDENCE_COPY[id].title}`)
+    }
+    setText(evidenceTitle, EVIDENCE_COPY[selected].title)
+    setText(evidenceSource, EVIDENCE_COPY[selected].source)
+    setText(evidenceReading, evidenceText(selected))
+    setText(guidance, EVIDENCE_COPY[selected].guidance)
+    guidance.hidden = state.mode === 'challenge'
+    recordButton.hidden = state.phase !== 'investigating'
+    recordButton.disabled = !!state.evidence[selected] || !vacuumEvidenceAvailable(selected, reading)
+    setText(recordButton, state.evidence[selected] ? 'Evidence recorded'
+      : recordButton.disabled ? 'Waiting for model evidence' : selected === 'owner' ? 'Acknowledge owner and abort consequences' : 'Record this evidence')
+    setText(notebookSummary, `Evidence notebook · ${count} of 4`)
+    causes.hidden = count < 4 || state.phase !== 'investigating'
+    for (const [cause, button] of causeButtons) button.setAttribute('aria-pressed', String(cause === state.cause))
+    setText(causeFeedback, state.cause === 'snapshot'
+      ? 'Supported: the old snapshot holds the cleanup horizon back. Vacuum can scan, but must preserve versions the snapshot might still need.'
+      : state.cause === 'disabled' ? 'Your worker evidence shows vacuum is running. Recheck the transaction evidence.'
+        : state.cause === 'capacity' ? 'More capacity cannot advance a retained snapshot’s cleanup horizon. Recheck the transaction evidence.' : '')
+    decision.hidden = causes.hidden || state.cause !== 'snapshot'
+    terminateButton.disabled = waitButton.disabled = !canChooseVacuumAction(state, reading)
+    setText(decisionStatus, reading.decisionReady ? 'Both choices affect this running city model.' : 'The incident is still being established. Keep the model running; your evidence remains saved.')
+    observation.hidden = state.phase === 'investigating'
+    recoverButton.hidden = state.action !== 'wait' || !reading.pinned || state.phase === 'complete'
+    verifyButton.hidden = state.phase === 'complete'
+    setText(result, state.phase === 'complete'
+      ? `Cleanup has resumed: ${fmtNum(reading.reclaimed)} row versions reclaimed across modeled tables since the decision. Remaining old versions may need further passes. Watch reusable capacity inside the existing relation, rather than expecting its file to shrink.`
+      : reading.pinned
+        ? `The old snapshot remains. sessions now has ${fmtNum(reading.deadRows)} dead versions; its relation occupies ${fmtBytes(reading.pages * 8192)}. The worker can keep scanning while retained versions accumulate.`
+        : `The old snapshot has ended. ${fmtNum(reading.reclaimed)} row versions reclaimed across modeled tables since the decision. Cleanup eligibility and actual collection are separate events.`)
+    setText(pauseButton, ctx.sim.state.knobs.paused ? 'Run model' : 'Pause model')
+    pauseButton.setAttribute('aria-pressed', String(ctx.sim.state.knobs.paused))
+    hintButton.hidden = state.mode === 'guided' || state.phase !== 'investigating'
+    retry.hidden = state.phase === 'investigating'
+  }
+
+  function refresh(): void { sample(); render() }
+
+  function open(mode: VacuumLessonMode = 'guided'): void {
+    if (opened) return
+    ctx.bus.emit('tour:stop', {})
+    lastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    if (lastFocus?.closest('.tour-first')) lastFocus = document.querySelector<HTMLElement>('.hud-investigate')
+    savedPaused = ctx.sim.state.knobs.paused
+    savedTimeScale = ctx.sim.state.knobs.timeScale
+    ctx.sim.endTrace()
+    ctx.bus.emit('narrate', null)
+    restorePaused = restoreTimeScale = true
+    opened = true
+    panel.hidden = false
+    document.body.classList.add('pg-vacuum-lesson')
+    state = createVacuumLessonState(mode)
+    selected = 'table'
+    notebook.replaceChildren()
+    notes.value = ''
+    observedWorker = ''
+    observedWorkerSlot = -1
+    reading.scanObserved = false
+    changingScenario = true
+    ctx.sim.runScenario('vacuum-blockade')
+    ownedDecision = ctx.sim.state.scenarioDecision
+    changingScenario = false
+    tableIndex = ctx.sim.state.tables.findIndex((table) => table.def.id === 'sessions')
+    reading.initialDeadRows = ctx.sim.state.tables[tableIndex].deadTuples
+    reading.initialPages = ctx.sim.state.tables[tableIndex].pages
+    setTiming('timeScale', 1)
+    setTiming('paused', reduceMotion() || ctx.getQuality().level === 'reduced' ? savedPaused : false)
+    announce('Inspect four evidence sources at your own pace. Starting this lesson applies a scenario to the current city; Exit restores its previous settings.')
+    focus(TABLE)
+    refresh()
+    title.focus()
+    progress('started')
+  }
+
+  function close(stopScenario = true, restoreTiming = true): void {
+    if (!opened) return
+    opened = false
+    panel.hidden = true
+    document.body.classList.remove('pg-vacuum-lesson')
+    if (stopScenario && ctx.sim.state.scenarioDecision === ownedDecision && ctx.sim.state.scenario === 'vacuum-blockade') ctx.sim.runScenario(null)
+    ownedDecision = null
+    if (restoreTiming && restorePaused) setTiming('paused', savedPaused)
+    if (restoreTiming && restoreTimeScale) setTiming('timeScale', savedTimeScale)
+    if (lastFocus && document.contains(lastFocus)) lastFocus.focus()
+    lastFocus = null
+  }
+
+  panel.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return
+    event.preventDefault()
+    event.stopPropagation()
+    close()
+  })
+  const off = [
+    ctx.bus.on('scenario', () => { if (opened && !changingScenario) close(false) }),
+    ctx.bus.on('sim:reset', () => close(false, false)),
+    ctx.bus.on('knob', ({ key }) => {
+      if (!opened || changingTiming) return
+      if (key === 'paused') restorePaused = false
+      if (key === 'timeScale') restoreTimeScale = false
+    }),
+    ctx.bus.on('tour:start', () => close()),
+    ctx.bus.on('trace:open', () => close()),
+    ctx.bus.on('ui:escape', (event) => {
+      if (!opened || event.handled) return
+      const anatomy = document.querySelector<HTMLElement>('.an-overlay')
+      if (anatomy && !anatomy.hidden) return
+      close()
+      event.handled = true
+    }),
+  ]
+
+  return {
+    open, close, isOpen: () => opened,
+    update(dt) {
+      if (!opened) return
+      if (ctx.sim.state.scenarioDecision !== ownedDecision) { close(false); return }
+      refreshIn -= dt
+      if (refreshIn > 0) return
+      refreshIn = 0.25
+      refresh()
+    },
+    dispose() {
+      for (const unsubscribe of off) unsubscribe()
+      close()
+      panel.remove()
+    },
+  }
+}


### PR DESCRIPTION
## Summary
Guided and challenge modes connect a growing-table question to captured evidence, intervention and observed cleanup. Persistent invitation/narration, a notebook, real model recovery verification, reduced-motion handling, shareable guided/challenge links and allowlisted aggregate outcome events are wired into the app.

Part of #14 / #10. Source commits 7f90d47 and 6c6d7dc.

## Verification and remaining gates
72 focused lesson/tour tests plus source-branch integration tests, typecheck and build passed in the reported runs. The integrated desktop challenge route rendered without exceptions and its screenshot was inspected.

**Draft:** QA found a desktop HUD overlap; layout refinement and phone verification remain. Full candidate tests and substantive REV review are required. This PR does not yet provide deterministic rewind or an unfamiliar variant; those remain #15 and #19. Lesson retry is not advertised as rewind.