### PR TITLE
feat: make incident replay reproducible

### DIFF
--- a/machine/mobile-layout.browser.test.js
+++ b/machine/mobile-layout.browser.test.js
@@ -241,6 +241,7 @@ describe('machine room portrait layout', () => {
         if (!window.PGSIMCITY) throw new Error('city API did not become ready')
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
         window.PGSIMCITY.bus.emit('select', { id: 'recovery.ground' })
       })()`,
     }, {
@@ -254,6 +255,7 @@ describe('machine room portrait layout', () => {
         if (!window.PGSIMCITY) throw new Error('city API did not become ready')
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
         window.PGSIMCITY.bus.emit('select', { id: 'client.pooler' })
       })()`,
     }])

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import { createWalkController } from './engine/walk'
 import { createViewmodelHands } from './engine/hands'
 
 import { createSim } from './sim/model'
+import { createIncidentReplay } from './sim/replay'
 
 import { createGround } from './world/ground'
 import { createSky } from './world/sky'
@@ -63,6 +64,7 @@ import { createHelp } from './ui/help'
 import { createControls } from './ui/controls'
 import { createInspector } from './ui/panel'
 import { createTour } from './ui/tour'
+import { createReplayPanel } from './ui/replay-panel'
 import { createSearch } from './ui/search'
 import { createCityWords } from './ui/city-words'
 import { createTouchpad } from './ui/touchpad'
@@ -153,6 +155,7 @@ async function boot(): Promise<void> {
 
   await progress(BOOT_STEPS.simulation)
   const sim = createSim(bus)
+  const replay = createIncidentReplay(sim, bus)
   if (reduceMotion()) sim.setKnob('paused', true)
 
   // --- the context every district is built against ---------------------------
@@ -297,8 +300,10 @@ async function boot(): Promise<void> {
     door: controlCenterWorld.door,
     hands,
   })
+  const replayPanel = createReplayPanel(uiCtx, replay)
   const ui: UiModule[] = [
-    createHud(uiCtx),
+    replayPanel,
+    createHud(uiCtx, { onReplay: () => replayPanel.open() }),
     createTouchpad({ bus, walk }),
     controlCenter,
     createWalkUpInteraction({
@@ -539,6 +544,7 @@ async function boot(): Promise<void> {
     timer.disconnect()
     for (const m of modules) m.dispose?.()
     for (const u of ui) u.dispose()
+    replay.dispose()
     flows.dispose()
     labels.dispose()
     picker.dispose()
@@ -572,6 +578,8 @@ async function boot(): Promise<void> {
   // notes and tooling still reach for it; both names are the same object.
   const handle = {
     sim,
+    replay,
+    replayPanel,
     registry,
     bus,
     rig,

--- a/src/sim/model.ts
+++ b/src/sim/model.ts
@@ -562,6 +562,8 @@ function makeExtra(): Extra {
  * ------------------------------------------------------------------------*/
 
 export interface SimOptions {
+  /** Workload seed retained across resets and encoded in reproducible lessons. */
+  seed?: number
   /** Aggregate probes may trade frame resolution for fewer deterministic steps. */
   maxStep?: number
   /** Aggregate mechanism probes may isolate themselves from the daily DR job. */
@@ -599,7 +601,22 @@ export interface ModelStateSizeObservation {
   traceRequests: number
 }
 
+interface SimulationReplayConfiguration {
+  seed: number
+  standard: boolean
+}
+const replayConfigurations = new WeakMap<SimApi, Readonly<SimulationReplayConfiguration>>()
+
+/** Replay must identify the exact model instance, including probe-only options. */
+export function simulationReplayConfiguration(sim: SimApi): Readonly<SimulationReplayConfiguration> | undefined {
+  return replayConfigurations.get(sim)
+}
+
 export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi {
+  const seed = options.seed ?? 0xc0ffee
+  if (!Number.isInteger(seed) || seed < 0 || seed > 0xffff_ffff) {
+    throw new Error(`invalid simulation seed: ${seed}`)
+  }
   const maxStep = options.maxStep ?? STEP_MAX
   const scheduledBackups = options.scheduledBackups ?? true
   const latencyObserver = options.latencyObserver
@@ -608,9 +625,9 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
   if (!isFinite(maxStep) || maxStep <= 0 || maxStep > STEP_MAX * MAX_STEPS) {
     throw new Error(`invalid simulation maxStep: ${maxStep}`)
   }
-  const rng = makeRng(0xc0ffee)
+  let rng = makeRng(seed)
   // Particle sampling must not perturb workload selection when I/O rates move.
-  const presentationRng = makeRng(0x10cafe)
+  let presentationRng = makeRng(0x10cafe)
   const rr = (lo: number, hi: number) => lo + (hi - lo) * rng()
 
   /* ---- state skeleton (built once, then reset in place: world modules hold
@@ -8781,6 +8798,19 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
    * ====================================================================*/
 
   function hardReset(): void {
+    rng = makeRng(seed)
+    presentationRng = makeRng(0x10cafe)
+    planSeq = 1
+    bgwT = 0
+    forkCooldown = 0
+    logicalAcc = 0
+    statT = 0
+    pageBudget = 0
+    flowTokens = 60
+    flushDur = 0
+    ckptSyncDur = 1.5
+    oldestLiveFpiGeneration = 0
+    lockTable = 3
     Object.assign(K, DEFAULT_KNOBS)
     liveDeficit = 0
     state.t = 0
@@ -9354,7 +9384,7 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
   // it must not announce a user-requested reset.
   initializeWarmState()
 
-  return {
+  const api: SimApi = {
     state,
     update,
     setKnob,
@@ -9373,4 +9403,6 @@ export function createSim(bus: Bus, options: Readonly<SimOptions> = {}): SimApi 
     startPgRewind,
     reset,
   }
+  replayConfigurations.set(api, { seed, standard: maxStep === STEP_MAX && scheduledBackups })
+  return api
 }

--- a/src/sim/replay.test.ts
+++ b/src/sim/replay.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'vitest'
+import { createBus } from '../core/bus'
+import { createSim } from './model'
+import { SCENARIOS } from './scenarios'
+import {
+  createIncidentReplay,
+  decodeReplay,
+  encodeReplay,
+  REPLAY_MAX_ACTIONS,
+  REPLAY_MAX_TICKS,
+} from './replay'
+
+const STEP = 1 / 30
+
+function run(sim: ReturnType<typeof createSim>, steps: number): void {
+  for (let i = 0; i < steps; i++) sim.update(STEP)
+}
+
+describe('reproducible incident initialization', () => {
+  it('restores the same complete warm state after prior work', () => {
+    const sim = createSim(createBus())
+    const initial = structuredClone(sim.state)
+    sim.runScenario('vacuum-blockade')
+    run(sim, 600)
+    sim.reset()
+    expect(sim.state).toEqual(initial)
+  })
+
+  it('repeats a seeded workload and distinguishes another seed', () => {
+    const first = createSim(createBus(), { seed: 42 })
+    const repeat = createSim(createBus(), { seed: 42 })
+    const other = createSim(createBus(), { seed: 43 })
+    run(first, 90)
+    run(repeat, 90)
+    run(other, 90)
+    expect(first.state).toEqual(repeat.state)
+    expect(first.state.backends).not.toEqual(other.state.backends)
+  })
+
+  it.each([-1, 0x1_0000_0000, 1.5, NaN, Infinity])('rejects invalid seed %s', (seed) => {
+    expect(() => createSim(createBus(), { seed })).toThrow('seed')
+  })
+
+  it.each(SCENARIOS.map((scenario) => scenario.id))('resets all warm state after %s', (id) => {
+    const sim = createSim(createBus(), { seed: 7 })
+    const initial = structuredClone(sim.state)
+    sim.runScenario(id)
+    run(sim, 123)
+    sim.reset()
+    expect(sim.state).toEqual(initial)
+  })
+})
+
+function incident(seed = 42) {
+  const bus = createBus()
+  const sim = createSim(bus, { seed })
+  const replay = createIncidentReplay(sim, bus, { seed })
+  return { sim, bus, replay }
+}
+
+describe('bounded incident replay', () => {
+  it('counts overlapping physical slot WAL retention once', async () => {
+    const { sim, replay } = incident()
+    sim.state.replication.physicalSlots[0].retainedBytes = 100
+    sim.state.replication.physicalSlots[1].retainedBytes = 150
+    await replay.rewind(0)
+    expect(replay.compare()?.baseline.retainedWalBytes).toBe(150)
+    replay.dispose()
+  })
+  it('notifies restored listeners only after reconstructed state is ready', async () => {
+    const { sim, replay } = incident()
+    run(sim, 70)
+    const expected = structuredClone(sim.state)
+    let calls = 0
+    const unsubscribe = replay.onRestored(() => {
+      expect(replay.status.seeking).toBe(false)
+      expect(sim.state).toEqual(expected)
+      calls++
+    })
+    await replay.rewind(70)
+    expect(calls).toBe(1)
+    unsubscribe()
+    await replay.rewind(70)
+    expect(calls).toBe(1)
+    replay.dispose()
+  })
+  it('rejects an incorrect seed and nonstandard model step configuration at attachment', () => {
+    const bus = createBus()
+    const sim = createSim(bus, { seed: 43 })
+    expect(() => createIncidentReplay(sim, bus, { seed: 42 })).toThrow(/seed/i)
+    const probeBus = createBus()
+    const probe = createSim(probeBus, { maxStep: 0.1 })
+    expect(() => createIncidentReplay(probe, probeBus)).toThrow(/configuration/i)
+  })
+
+  it('exports only the restored prefix while retaining future ticks until a branch starts', async () => {
+    const { sim, replay } = incident()
+    sim.setKnob('tps', 500)
+    run(sim, 10)
+    const prefix = replay.checkpoint()
+    const initial = structuredClone(sim.state)
+    sim.setKnob('workMem', 64)
+    run(sim, 10)
+    const end = structuredClone(sim.state)
+    await replay.rewind(prefix)
+    expect(sim.state).toEqual(initial)
+    expect(replay.status.totalTicks).toBe(20)
+    expect(replay.status.tick).toBe(10)
+    expect(replay.exportRecord().ticks).toBe(10)
+    expect(replay.exportRecord().actions).toHaveLength(1)
+    await replay.rewind(20)
+    expect(sim.state).toEqual(end)
+    await replay.rewind(prefix)
+    sim.setKnob('workMem', 128)
+    sim.update(STEP)
+    expect(replay.status.totalTicks).toBe(11)
+    expect(replay.exportRecord().actions.at(-1)).toMatchObject({ key: 'workMem', value: 128 })
+    await expect(replay.rewind(20)).rejects.toThrow()
+    replay.dispose()
+  })
+
+  it('preserves same-tick before/after action checkpoints without dropping earlier actions', async () => {
+    const { sim, replay } = incident()
+    sim.setKnob('workMem', 8)
+    const first = replay.checkpoint()
+    sim.setKnob('workMem', 64)
+    run(sim, 1)
+    await replay.rewind(first)
+    expect(sim.state.knobs.workMem).toBe(8)
+    expect(replay.exportRecord().actions).toHaveLength(1)
+    await expect(replay.rewind({ tick: 1, actionCount: 0 })).rejects.toThrow(/order/i)
+    replay.dispose()
+  })
+
+  it('restores complete state, same-tick action order, and shared state references', async () => {
+    const { sim, replay } = incident()
+    const state = sim.state
+    const buffers = state.buffers
+    const backends = state.backends
+    sim.runScenario('vacuum-blockade')
+    run(sim, 180)
+    const point = replay.checkpoint()
+    const expected = structuredClone(state)
+    sim.setKnob('tps', 1400, 'user')
+    sim.setKnob('timeScale', 2, 'user')
+    run(sim, 90)
+    await replay.rewind(point)
+    expect(sim.state).toBe(state)
+    expect(sim.state.buffers).toBe(buffers)
+    expect(sim.state.backends).toBe(backends)
+    expect(sim.state).toEqual(expected)
+    expect(replay.status.seeking).toBe(false)
+    const record = replay.exportRecord()
+    const repeat = incident()
+    await repeat.replay.loadRecord(record)
+    expect(repeat.sim.state).toEqual(expected)
+    replay.dispose()
+    repeat.replay.dispose()
+  })
+
+  it('rewinds a real decision, records another branch, and compares measured model outcomes', async () => {
+    const { sim, replay } = incident()
+    sim.runScenario('vacuum-blockade')
+    for (let i = 0; i < 1800 && sim.state.scenarioDecision?.phase !== 'ready'; i++) sim.update(STEP)
+    expect(sim.state.scenarioDecision?.phase).toBe('ready')
+    const decision = replay.checkpoint()
+    const staged = structuredClone(sim.state)
+    expect(sim.chooseScenario('wait-for-transaction')).toBe(true)
+    sim.setKnob('tps', 1800, 'user')
+    run(sim, 90)
+    const waiting = structuredClone(sim.state)
+    const waitingRecord = replay.exportRecord()
+    await replay.rewind(decision)
+    expect(sim.state).toEqual(staged)
+    expect(sim.chooseScenario('terminate-transaction')).toBe(true)
+    sim.setKnob('tps', 1800, 'user')
+    run(sim, 90)
+    const alternative = structuredClone(sim.state)
+    expect(alternative.knobs.longRunningXact).toBe(false)
+    expect(waiting.knobs.longRunningXact).toBe(true)
+    expect(replay.compare()?.sameDuration).toBe(true)
+    expect(replay.compare()?.baseline.elapsedTicks).toBe(replay.compare()?.current.elapsedTicks)
+    const alternativeRecord = replay.exportRecord()
+    expect(alternativeRecord.actions.some((action) => action.type === 'decision' && action.choice === 'wait-for-transaction')).toBe(false)
+    await replay.loadRecord(waitingRecord)
+    expect(sim.state).toEqual(waiting)
+    await replay.loadRecord(alternativeRecord)
+    expect(sim.state).toEqual(alternative)
+    replay.dispose()
+  }, 30_000)
+
+  it('records direct and bus actions once while ignoring scenario-generated changes', async () => {
+    const { sim, bus, replay } = incident()
+    bus.emit('scenario', { id: 'work-mem-spill' })
+    bus.emit('knob', { key: 'tps', value: 500, source: 'user' })
+    sim.setKnob('workMem', 16, 'user')
+    run(sim, 45)
+    expect(replay.exportRecord().actions.map((action) => action.type)).toEqual(['scenario', 'knob', 'knob'])
+    const expected = structuredClone(sim.state)
+    const record = replay.exportRecord()
+    await replay.loadRecord(record)
+    expect(sim.state).toEqual(expected)
+    replay.dispose()
+  })
+
+  it('does not replay a duplicate bus scenario as a scenario restart', async () => {
+    const { sim, bus, replay } = incident()
+    bus.emit('scenario', { id: 'vacuum-blockade' })
+    run(sim, 45)
+    bus.emit('scenario', { id: 'vacuum-blockade' })
+    run(sim, 3)
+    const expected = structuredClone(sim.state)
+    const record = replay.exportRecord()
+    await replay.loadRecord(record)
+    expect(sim.state).toEqual(expected)
+    replay.dispose()
+  })
+
+  it('records exact update durations and pause boundaries without a per-frame action', async () => {
+    const { sim, replay } = incident()
+    sim.update(1 / 60)
+    sim.update(1 / 60)
+    sim.setKnob('paused', true)
+    sim.update(0.1)
+    sim.setKnob('paused', false)
+    sim.setKnob('timeScale', 3)
+    sim.update(0.1)
+    expect(replay.status.tick).toBe(3)
+    const expected = structuredClone(sim.state)
+    const record = replay.exportRecord()
+    expect(record.steps).toEqual([{ count: 2, dt: 1 / 60 }, { count: 1, dt: 0.1 }])
+    await replay.loadRecord(record)
+    expect(sim.state).toEqual(expected)
+    replay.dispose()
+  })
+
+  it('exposes seeking during reset events and yields without advancing from live frames', async () => {
+    const { sim, bus, replay } = incident()
+    run(sim, 70)
+    const expected = structuredClone(sim.state)
+    const seekingAtReset: boolean[] = []
+    bus.on('sim:reset', () => seekingAtReset.push(replay.status.seeking))
+    const seek = replay.rewind(70)
+    expect(replay.status.seeking).toBe(true)
+    sim.update(2)
+    expect(() => sim.setKnob('tps', 1)).toThrow(/seeking|rewind/i)
+    await seek
+    expect(sim.state).toEqual(expected)
+    expect(seekingAtReset.length).toBeGreaterThan(0)
+    expect(seekingAtReset.every(Boolean)).toBe(true)
+    replay.dispose()
+  })
+
+  it.each(['startBaseBackup', 'startPgRewind', 'endTrace'] as const)(
+    'invalidates export after unsupported mutation %s until reset', (method) => {
+      const { sim, replay } = incident()
+      sim[method]()
+      expect(replay.status.valid).toBe(false)
+      expect(() => replay.exportRecord()).toThrow(/unsupported/i)
+      sim.reset()
+      expect(replay.status.valid).toBe(true)
+      expect(replay.status.tick).toBe(0)
+      replay.dispose()
+    },
+  )
+
+  it('stops recording explicitly at the action limit without blocking the model', () => {
+    const { sim, replay } = incident()
+    for (let i = 0; i <= REPLAY_MAX_ACTIONS; i++) sim.setKnob('tps', i % 2 ? 100 : 200)
+    expect(replay.status.actionCount).toBe(REPLAY_MAX_ACTIONS)
+    expect(sim.state.knobs.tps).toBe(200)
+    expect(() => replay.exportRecord()).toThrow(/limit/i)
+    replay.dispose()
+  })
+
+  it('round-trips owned share data and rejects hostile records before changing state', async () => {
+    const { sim, replay } = incident()
+    sim.runScenario('vacuum-blockade')
+    run(sim, 3)
+    const record = replay.exportRecord()
+    expect(decodeReplay(encodeReplay(record))).toEqual(record)
+    const expected = structuredClone(sim.state)
+    const badRecords: unknown[] = [
+      { ...record, version: 999 },
+      { ...record, modelVersion: 'different-model' },
+      { ...record, seed: 43 },
+      { ...record, ticks: REPLAY_MAX_TICKS + 1 },
+      { ...record, steps: [{ count: 3, dt: Infinity }] },
+      { ...record, steps: [{ count: 3, dt: -1 }] },
+      { ...record, steps: [{ count: 3, dt: 1000 }] },
+      { ...record, actions: [{ tick: 0, type: 'knob', key: '__proto__', value: {} }] },
+      { ...record, actions: [{ tick: 0, type: 'knob', key: 'tps', value: 1e100 }] },
+      { ...record, actions: [{ tick: 0, type: 'scenario', id: '<script>' }] },
+      { ...record, actions: [{ tick: 0, type: 'decision', choice: 'arbitrary-code' }] },
+      { ...record, actions: [{ tick: 4, type: 'recover' }] },
+      { ...record, actions: [{ tick: 2, type: 'recover' }, { tick: 1, type: 'recover' }] },
+      { ...record, actions: Array(REPLAY_MAX_ACTIONS + 1).fill({ tick: 0, type: 'recover' }) },
+      JSON.parse('{"__proto__":{"polluted":true}}'),
+    ]
+    for (const bad of badRecords) {
+      await expect(replay.loadRecord(bad)).rejects.toThrow()
+      expect(sim.state).toEqual(expected)
+    }
+    expect(() => decodeReplay('['.repeat(100_000))).toThrow(/size|large|limit/i)
+    expect(() => decodeReplay('not json')).toThrow()
+    replay.dispose()
+  })
+})

--- a/src/sim/replay.test.ts
+++ b/src/sim/replay.test.ts
@@ -59,6 +59,15 @@ function incident(seed = 42) {
 }
 
 describe('bounded incident replay', () => {
+  it('withdraws comparisons after an unsupported action invalidates their provenance', async () => {
+    const { sim, replay } = incident()
+    sim.update(STEP)
+    await replay.rewind(0)
+    expect(replay.compare()).not.toBeNull()
+    sim.startBaseBackup()
+    expect(replay.compare()).toBeNull()
+    replay.dispose()
+  })
   it('does not block model clamping when a live action exceeds share bounds', () => {
     const { sim, replay } = incident()
     expect(() => sim.setKnob('workMem', 1000)).not.toThrow()

--- a/src/sim/replay.test.ts
+++ b/src/sim/replay.test.ts
@@ -59,6 +59,43 @@ function incident(seed = 42) {
 }
 
 describe('bounded incident replay', () => {
+  it('does not block model clamping when a live action exceeds share bounds', () => {
+    const { sim, replay } = incident()
+    expect(() => sim.setKnob('workMem', 1000)).not.toThrow()
+    expect(sim.state.knobs.workMem).toBe(256)
+    expect(replay.status.valid).toBe(false)
+    expect(() => replay.exportRecord()).toThrow(/unsupported|bounds/i)
+    replay.dispose()
+  })
+  it('records clearing a trace before opening a lesson without invalidating replay', async () => {
+    const { sim, replay } = incident()
+    sim.setKnob('paused', true)
+    sim.endTrace()
+    sim.runScenario('vacuum-blockade')
+    sim.update(STEP)
+    expect(replay.status.valid).toBe(true)
+    const expected = structuredClone(sim.state)
+    await replay.loadRecord(replay.exportRecord())
+    expect(sim.state).toEqual(expected)
+    replay.dispose()
+  })
+  it('runs an alternative to exactly the saved comparison duration and pauses there', async () => {
+    const { sim, replay } = incident()
+    run(sim, 10)
+    const point = replay.checkpoint()
+    run(sim, 80)
+    await replay.rewind(point)
+    sim.setKnob('workMem', 64)
+    await replay.runToComparison()
+    expect(replay.compare()?.sameDuration).toBe(true)
+    expect(replay.status.tick).toBe(90)
+    expect(sim.state.knobs.paused).toBe(true)
+    expect(sim.state.knobs.workMem).toBe(64)
+    const end = structuredClone(sim.state)
+    await replay.loadRecord(replay.exportRecord())
+    expect(sim.state).toEqual(end)
+    replay.dispose()
+  })
   it('counts overlapping physical slot WAL retention once', async () => {
     const { sim, replay } = incident()
     sim.state.replication.physicalSlots[0].retainedBytes = 100
@@ -251,7 +288,7 @@ describe('bounded incident replay', () => {
     replay.dispose()
   })
 
-  it.each(['startBaseBackup', 'startPgRewind', 'endTrace'] as const)(
+  it.each(['startBaseBackup', 'startPgRewind', 'startFailover'] as const)(
     'invalidates export after unsupported mutation %s until reset', (method) => {
       const { sim, replay } = incident()
       sim[method]()

--- a/src/sim/replay.test.ts
+++ b/src/sim/replay.test.ts
@@ -59,6 +59,83 @@ function incident(seed = 42) {
 }
 
 describe('bounded incident replay', () => {
+  it('keeps the default vacuum recovery reproducible past the original ten-minute cap', async () => {
+    const { sim, replay } = incident(0xc0ffee)
+    sim.runScenario('vacuum-blockade')
+    expect(await replay.advanceUntil(() => sim.state.scenarioDecision?.phase === 'ready', { maxTicks: 3000 })).toBe('condition')
+    expect(sim.chooseScenario('terminate-transaction')).toBe(true)
+    expect(await replay.advanceUntil(() => sim.state.scenarioDecision?.phase === 'recovered', { maxTicks: 30_000 })).toBe('condition')
+    expect(replay.status.tick).toBeGreaterThan(18_000)
+    expect(replay.status.valid).toBe(true)
+    const expected = structuredClone(sim.state)
+    await replay.loadRecord(replay.exportRecord())
+    expect(sim.state).toEqual(expected)
+    replay.dispose()
+  })
+  it('advances explicitly beyond ten minutes with exact fixed-step recording', async () => {
+    const { sim, replay } = incident()
+    const result = await replay.advanceUntil(() => replay.status.tick >= 18_100, { maxTicks: 18_100 })
+    expect(result).toBe('condition')
+    expect(replay.status.valid).toBe(true)
+    const record = replay.exportRecord()
+    expect(record.version).toBe(2)
+    expect(record.steps).toEqual([{ count: 18_100, dt: STEP }])
+    const expected = structuredClone(sim.state)
+    await replay.loadRecord(record)
+    expect(sim.state).toEqual(expected)
+    replay.dispose()
+  })
+
+  it('locks wall updates during cancellable advancement and restores prior pause', async () => {
+    const { sim, replay } = incident()
+    sim.setKnob('paused', true)
+    const abort = new AbortController()
+    const advancing = replay.advanceUntil(() => false, { maxTicks: 200, signal: abort.signal })
+    expect(replay.status.advancing).toBe(true)
+    const tick = replay.status.tick
+    sim.update(STEP)
+    expect(replay.status.tick).toBe(tick)
+    expect(() => sim.setKnob('workMem', 16)).toThrow(/advancing/i)
+    abort.abort()
+    expect(replay.status.advancing).toBe(false)
+    expect(() => sim.runScenario('vacuum-blockade')).not.toThrow()
+    expect(await advancing).toBe('cancelled')
+    expect(replay.status.advancing).toBe(false)
+    expect(sim.state.knobs.paused).toBe(true)
+    expect(replay.status.valid).toBe(true)
+    const expected = structuredClone(sim.state)
+    await replay.loadRecord(replay.exportRecord())
+    expect(sim.state).toEqual(expected)
+    replay.dispose()
+  })
+
+  it('cancels advancement synchronously before reset without resuming an old incident', async () => {
+    const { sim, replay } = incident()
+    const initial = structuredClone(sim.state)
+    const pending = replay.advanceUntil(() => false, { maxTicks: 200 })
+    sim.reset()
+    expect(replay.status.advancing).toBe(false)
+    expect(await pending).toBe('cancelled')
+    expect(sim.state).toEqual(initial)
+    expect(replay.status.tick).toBe(0)
+    replay.dispose()
+  })
+
+  it('bounds explicit advancement and rejects older format before mutation', async () => {
+    const { sim, replay } = incident()
+    const initial = structuredClone(sim.state)
+    await expect(replay.advanceUntil(() => false, { maxTicks: REPLAY_MAX_TICKS + 1 })).rejects.toThrow(/limit/i)
+    await expect(replay.loadRecord({ ...replay.exportRecord(), version: 1 })).rejects.toThrow(/version/i)
+    const fullBudget = { ...replay.exportRecord(), ticks: REPLAY_MAX_TICKS,
+      steps: [{ count: REPLAY_MAX_TICKS, dt: STEP }] }
+    expect(decodeReplay(encodeReplay(fullBudget)).ticks).toBe(54_000)
+    expect(() => encodeReplay({ ...fullBudget, steps: [{ count: REPLAY_MAX_TICKS, dt: STEP + 0.001 }] })).toThrow(/duration/i)
+    expect(sim.state).toEqual(initial)
+    expect(await replay.advanceUntil(() => false, { maxTicks: 2 })).toBe('limit')
+    expect(replay.status.tick).toBe(2)
+    expect(replay.status.valid).toBe(true)
+    replay.dispose()
+  })
   it('withdraws comparisons after an unsupported action invalidates their provenance', async () => {
     const { sim, replay } = incident()
     sim.update(STEP)

--- a/src/sim/replay.ts
+++ b/src/sim/replay.ts
@@ -19,6 +19,7 @@ export type ReplayAction = { tick: number } & (
   | { type: 'scenario'; id: string | null }
   | { type: 'decision'; choice: ScenarioChoiceId }
   | { type: 'recover' }
+  | { type: 'end-trace' }
 )
 
 export interface ReplayRecord {
@@ -132,8 +133,9 @@ function action(value: unknown, ticks: number): ReplayAction {
       if (!choices.has(item.choice as ScenarioChoiceId)) throw new Error('Invalid replay decision')
       return { tick, type: 'decision', choice: item.choice as ScenarioChoiceId }
     case 'recover':
+    case 'end-trace':
       fields(item, ['tick', 'type'])
-      return { tick, type: 'recover' }
+      return { tick, type: item.type }
     default:
       throw new Error('Unsupported replay action')
   }
@@ -214,6 +216,7 @@ export function createIncidentReplay(
   let busy = 0
   let disposed = false
   let baseline: ReplayOutcome | null = null
+  let baselineDurations: Float64Array | null = null
   const restoredListeners = new Set<() => void>()
 
   function notify(): void { options.onChange?.() }
@@ -248,9 +251,14 @@ export function createIncidentReplay(
   }
   function invoke<T>(next: ReplayAction, execute: () => T): T {
     requireReady()
-    record(action(next, status.tick))
+    recordLive(next)
     busy++
     try { return execute() } finally { busy-- }
+  }
+  function recordLive(next: unknown): void {
+    if (!status.valid) return
+    try { record(action(next, status.tick)) }
+    catch { invalidate('Unsupported live action outside replay bounds; reset to record another incident') }
   }
   function apply(next: ReplayAction): void {
     switch (next.type) {
@@ -258,6 +266,7 @@ export function createIncidentReplay(
       case 'scenario': original.runScenario(next.id); break
       case 'decision': original.chooseScenario(next.choice); break
       case 'recover': original.recoverScenario(); break
+      case 'end-trace': original.endTrace(); break
     }
   }
   function outcome(): ReplayOutcome {
@@ -278,8 +287,7 @@ export function createIncidentReplay(
     }
   }
 
-  sim.update = (dt: number): void => {
-    if (status.seeking) return
+  function advance(dt: number): void {
     if (Number.isFinite(dt) && dt > 0 && !sim.state.knobs.paused) {
       if (status.valid) {
         branch()
@@ -296,6 +304,7 @@ export function createIncidentReplay(
     busy++
     try { original.update(dt) } finally { busy-- }
   }
+  sim.update = (dt: number): void => { if (!status.seeking) advance(dt) }
   sim.setKnob = (key, value, source) => invoke(
     { tick: status.tick, type: 'knob', key, value, ...(source ? { source } : {}) },
     () => original.setKnob(key, value, source),
@@ -303,6 +312,7 @@ export function createIncidentReplay(
   sim.runScenario = (id) => invoke({ tick: status.tick, type: 'scenario', id }, () => original.runScenario(id))
   sim.chooseScenario = (choice) => invoke({ tick: status.tick, type: 'decision', choice }, () => original.chooseScenario(choice))
   sim.recoverScenario = () => invoke({ tick: status.tick, type: 'recover' }, () => original.recoverScenario())
+  sim.endTrace = () => invoke({ tick: status.tick, type: 'end-trace' }, () => original.endTrace())
 
   bus.emit = <K extends keyof BusEvents>(type: K, payload: BusEvents[K]): void => {
     if (status.seeking && (type === 'flow' || type === 'toast' || type === 'narrate' || type === 'focus')) return
@@ -313,7 +323,7 @@ export function createIncidentReplay(
       requireReady()
       // The bus ignores a repeated scenario; a direct runScenario restarts it.
       if (type !== 'scenario' || (payload as BusEvents['scenario']).id !== sim.state.scenario) {
-        record(action(next, status.tick))
+        recordLive(next)
       }
       busy++
       try { originalEmit(type, payload) } finally { busy-- }
@@ -323,7 +333,7 @@ export function createIncidentReplay(
   }
 
   const unsupported = [
-    'request', 'setTraceMode', 'endTrace', 'startBaseBackup', 'startPointInTimeRestore',
+    'request', 'setTraceMode', 'startBaseBackup', 'startPointInTimeRestore',
     'startRestoreDrill', 'setLeaderOpinion', 'startSwitchover', 'startFailover', 'startPgRewind',
   ] as const
   for (const method of unsupported) {
@@ -345,6 +355,7 @@ export function createIncidentReplay(
     status.seekProgress = 0
     elapsed = 0
     baseline = null
+    baselineDurations = null
     busy++
     try { original.reset() } finally { busy-- }
     originTime = sim.state.t
@@ -408,7 +419,33 @@ export function createIncidentReplay(
       requireValid()
       const target = pointAt(value)
       baseline = outcome()
+      baselineDurations = durations.slice(0, status.tick)
       await seek(target)
+    },
+    async runToComparison(): Promise<void> {
+      requireValid()
+      if (!baseline || !baselineDurations) throw new Error('Rewind a completed branch before comparing')
+      const remaining = baseline.elapsedModelSeconds - (sim.state.t - originTime)
+      if (remaining < -1e-7) throw new Error('Alternative is already beyond the comparison duration; rewind again')
+      sim.setKnob('paused', false)
+      status.seeking = true
+      notify()
+      try {
+        let steps = 0
+        while (baseline.elapsedModelSeconds - (sim.state.t - originTime) > 1e-7) {
+          if (disposed) throw new Error('Replay controller was disposed during comparison')
+          const dt = Math.min(baselineDurations[status.tick] ?? 1 / 30,
+            baseline.elapsedModelSeconds - (sim.state.t - originTime))
+          advance(dt)
+          if (!status.valid) throw new Error(status.reason)
+          status.seekProgress = (sim.state.t - originTime) / Math.max(1e-7, baseline.elapsedModelSeconds)
+          if (++steps % SEEK_BATCH === 0) await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        }
+      } finally {
+        status.seeking = false
+        if (!disposed) sim.setKnob('paused', true)
+        notify()
+      }
     },
     compare(): { baseline: ReplayOutcome; current: ReplayOutcome; sameDuration: boolean } | null {
       if (!baseline) return null
@@ -446,6 +483,7 @@ export function createIncidentReplay(
       status.reason = ''
       status.totalTicks = record.ticks
       baseline = null
+      baselineDurations = null
       await seek({ tick: record.ticks, actionCount: log.length })
     },
     reset,

--- a/src/sim/replay.ts
+++ b/src/sim/replay.ts
@@ -448,7 +448,7 @@ export function createIncidentReplay(
       }
     },
     compare(): { baseline: ReplayOutcome; current: ReplayOutcome; sameDuration: boolean } | null {
-      if (!baseline) return null
+      if (!baseline || !status.valid) return null
       const current = outcome()
       return { baseline: { ...baseline }, current,
         sameDuration: Math.abs(baseline.elapsedModelSeconds - current.elapsedModelSeconds) < 1e-7 }

--- a/src/sim/replay.ts
+++ b/src/sim/replay.ts
@@ -4,11 +4,12 @@ import type { Bus, BusEvents, Knobs, ScenarioChoiceId, SimApi } from '../core/ty
 import { simulationReplayConfiguration } from './model'
 import { SCENARIOS } from './scenarios'
 
-export const REPLAY_MAX_TICKS = 18_000
+export const REPLAY_MAX_TICKS = 54_000
 export const REPLAY_MAX_ACTIONS = 1024
 export const REPLAY_MAX_BYTES = 96 * 1024
-export const REPLAY_MODEL_VERSION = `incident-1/${BUILD_VERSION}/${BUILD_SHA}`
-const MAX_MODEL_SECONDS = 600
+export const REPLAY_MODEL_VERSION = `incident-2/${BUILD_VERSION}/${BUILD_SHA}`
+const MAX_MODEL_SECONDS = 1800
+const ADVANCE_STEP = 1 / 30
 const MAX_DELTA = 2
 const SEEK_BATCH = 64
 const attached = new WeakSet<SimApi>()
@@ -23,7 +24,7 @@ export type ReplayAction = { tick: number } & (
 )
 
 export interface ReplayRecord {
-  version: 1
+  version: 2
   modelVersion: string
   seed: number
   ticks: number
@@ -42,6 +43,7 @@ export interface ReplayStatus extends ReplayPoint {
   valid: boolean
   reason: string
   seeking: boolean
+  advancing: boolean
   seekProgress: number
 }
 
@@ -144,7 +146,7 @@ function action(value: unknown, ticks: number): ReplayAction {
 function validateRecord(value: unknown): ReplayRecord {
   const item = object(value)
   fields(item, ['version', 'modelVersion', 'seed', 'ticks', 'steps', 'actions'])
-  if (item.version !== 1) throw new Error('Unsupported replay format version')
+  if (item.version !== 2) throw new Error('Unsupported replay format version')
   if (item.modelVersion !== REPLAY_MODEL_VERSION) throw new Error('Replay model-version mismatch')
   const seed = integer(item.seed, 0, 0xffff_ffff, 'seed')
   const ticks = integer(item.ticks, 0, REPLAY_MAX_TICKS, 'tick limit')
@@ -174,7 +176,7 @@ function validateRecord(value: unknown): ReplayRecord {
     previous = parsed.tick
     actions.push(parsed)
   }
-  return { version: 1, modelVersion: REPLAY_MODEL_VERSION, seed, ticks, steps, actions }
+  return { version: 2, modelVersion: REPLAY_MODEL_VERSION, seed, ticks, steps, actions }
 }
 
 export function encodeReplay(value: unknown): string {
@@ -209,7 +211,7 @@ export function createIncidentReplay(
   const durations = new Float64Array(REPLAY_MAX_TICKS)
   const log: ReplayAction[] = []
   const status: ReplayStatus = {
-    tick: 0, actionCount: 0, totalTicks: 0, valid: true, reason: '', seeking: false, seekProgress: 0,
+    tick: 0, actionCount: 0, totalTicks: 0, valid: true, reason: '', seeking: false, advancing: false, seekProgress: 0,
   }
   let elapsed = 0
   let originTime = sim.state.t
@@ -218,6 +220,7 @@ export function createIncidentReplay(
   let baseline: ReplayOutcome | null = null
   let baselineDurations: Float64Array | null = null
   const restoredListeners = new Set<() => void>()
+  let cancelAdvance: (() => void) | null = null
 
   function notify(): void { options.onChange?.() }
   function invalidate(reason: string): void {
@@ -229,6 +232,7 @@ export function createIncidentReplay(
   function requireReady(): void {
     if (disposed) throw new Error('Replay controller is disposed')
     if (status.seeking) throw new Error('Cannot change the model while seeking a replay')
+    if (status.advancing) throw new Error('Cannot change the model while advancing a replay')
   }
   function requireValid(): void {
     requireReady()
@@ -304,12 +308,15 @@ export function createIncidentReplay(
     busy++
     try { original.update(dt) } finally { busy-- }
   }
-  sim.update = (dt: number): void => { if (!status.seeking) advance(dt) }
+  sim.update = (dt: number): void => { if (!status.seeking && !status.advancing) advance(dt) }
   sim.setKnob = (key, value, source) => invoke(
     { tick: status.tick, type: 'knob', key, value, ...(source ? { source } : {}) },
     () => original.setKnob(key, value, source),
   )
-  sim.runScenario = (id) => invoke({ tick: status.tick, type: 'scenario', id }, () => original.runScenario(id))
+  sim.runScenario = (id) => {
+    cancelAdvance?.()
+    return invoke({ tick: status.tick, type: 'scenario', id }, () => original.runScenario(id))
+  }
   sim.chooseScenario = (choice) => invoke({ tick: status.tick, type: 'decision', choice }, () => original.chooseScenario(choice))
   sim.recoverScenario = () => invoke({ tick: status.tick, type: 'recover' }, () => original.recoverScenario())
   sim.endTrace = () => invoke({ tick: status.tick, type: 'end-trace' }, () => original.endTrace())
@@ -317,6 +324,7 @@ export function createIncidentReplay(
   bus.emit = <K extends keyof BusEvents>(type: K, payload: BusEvents[K]): void => {
     if (status.seeking && (type === 'flow' || type === 'toast' || type === 'narrate' || type === 'focus')) return
     if (!busy && (type === 'knob' || type === 'scenario')) {
+      if (type === 'scenario') cancelAdvance?.()
       const next = type === 'knob'
         ? { tick: status.tick, type: 'knob', ...(payload as BusEvents['knob']) }
         : { tick: status.tick, type: 'scenario', ...(payload as BusEvents['scenario']) }
@@ -347,6 +355,7 @@ export function createIncidentReplay(
   }
 
   function reset(): void {
+    cancelAdvance?.()
     requireReady()
     log.length = 0
     status.tick = status.totalTicks = status.actionCount = 0
@@ -410,6 +419,44 @@ export function createIncidentReplay(
 
   return {
     status: status as Readonly<ReplayStatus>,
+    cancelAdvance(): void { cancelAdvance?.() },
+    async advanceUntil(
+      predicate: () => boolean,
+      options: { maxTicks: number; signal?: AbortSignal },
+    ): Promise<'condition' | 'cancelled' | 'limit'> {
+      requireValid()
+      const maxTicks = integer(options.maxTicks, 1, REPLAY_MAX_TICKS, 'advancement tick limit')
+      if (options.signal?.aborted) return 'cancelled'
+      if (predicate()) return 'condition'
+      if (status.actionCount > REPLAY_MAX_ACTIONS - 2) throw new Error('Insufficient replay action capacity for advancement')
+      const paused = sim.state.knobs.paused
+      if (paused) sim.setKnob('paused', false)
+      status.advancing = true
+      let finished = false
+      const finish = (): void => {
+        if (finished) return
+        finished = true
+        options.signal?.removeEventListener('abort', finish)
+        cancelAdvance = null
+        status.advancing = false
+        if (!disposed && sim.state.knobs.paused !== paused) sim.setKnob('paused', paused)
+        notify()
+      }
+      cancelAdvance = finish
+      options.signal?.addEventListener('abort', finish, { once: true })
+      notify()
+      try {
+        for (let count = 0; count < maxTicks; count++) {
+          if (finished || disposed || options.signal?.aborted) return 'cancelled'
+          if (status.tick >= REPLAY_MAX_TICKS || elapsed + ADVANCE_STEP > MAX_MODEL_SECONDS + 1e-7) return 'limit'
+          advance(ADVANCE_STEP)
+          if (!status.valid) throw new Error(status.reason)
+          if (predicate()) return 'condition'
+          if ((count + 1) % SEEK_BATCH === 0) await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        }
+        return 'limit'
+      } finally { finish() }
+    },
     onRestored(listener: () => void): () => void {
       restoredListeners.add(listener)
       return () => { restoredListeners.delete(listener) }
@@ -462,7 +509,7 @@ export function createIncidentReplay(
         else steps.push({ count: 1, dt: durations[tick] })
       }
       const record: ReplayRecord = {
-        version: 1, modelVersion: REPLAY_MODEL_VERSION, seed, ticks: status.tick, steps,
+        version: 2, modelVersion: REPLAY_MODEL_VERSION, seed, ticks: status.tick, steps,
         actions: log.slice(0, status.actionCount).map((entry) => ({ ...entry })),
       }
       encodeReplay(record)
@@ -488,6 +535,7 @@ export function createIncidentReplay(
     },
     reset,
     dispose(): void {
+      cancelAdvance?.()
       disposed = true
       restoredListeners.clear()
       Object.assign(sim, original)

--- a/src/sim/replay.ts
+++ b/src/sim/replay.ts
@@ -1,0 +1,463 @@
+import { BUILD_SHA, BUILD_VERSION } from '../core/build'
+import { DEFAULT_KNOBS } from '../core/types'
+import type { Bus, BusEvents, Knobs, ScenarioChoiceId, SimApi } from '../core/types'
+import { simulationReplayConfiguration } from './model'
+import { SCENARIOS } from './scenarios'
+
+export const REPLAY_MAX_TICKS = 18_000
+export const REPLAY_MAX_ACTIONS = 1024
+export const REPLAY_MAX_BYTES = 96 * 1024
+export const REPLAY_MODEL_VERSION = `incident-1/${BUILD_VERSION}/${BUILD_SHA}`
+const MAX_MODEL_SECONDS = 600
+const MAX_DELTA = 2
+const SEEK_BATCH = 64
+const attached = new WeakSet<SimApi>()
+const attachedBuses = new WeakSet<Bus>()
+
+export type ReplayAction = { tick: number } & (
+  | { type: 'knob'; key: keyof Knobs; value: Knobs[keyof Knobs]; source?: 'user' }
+  | { type: 'scenario'; id: string | null }
+  | { type: 'decision'; choice: ScenarioChoiceId }
+  | { type: 'recover' }
+)
+
+export interface ReplayRecord {
+  version: 1
+  modelVersion: string
+  seed: number
+  ticks: number
+  steps: { count: number; dt: number }[]
+  actions: ReplayAction[]
+}
+
+export interface ReplayPoint {
+  tick: number
+  /** Distinguishes before and after a decision made without advancing time. */
+  actionCount: number
+}
+
+export interface ReplayStatus extends ReplayPoint {
+  totalTicks: number
+  valid: boolean
+  reason: string
+  seeking: boolean
+  seekProgress: number
+}
+
+export interface ReplayOutcome {
+  elapsedTicks: number
+  elapsedModelSeconds: number
+  scenario: string | null
+  commits: number
+  rollbacks: number
+  throughputTps: number
+  latencyP99ModelMs: number
+  deadTuples: number
+  tablePages: number
+  reclaimedTuples: number
+  retainedWalBytes: number
+  rejectedWrites: number
+  lostTransactions: number
+}
+
+const numericBounds: Partial<Record<keyof Knobs, readonly [number, number]>> = {
+  tps: [0, 10_000], clientConnections: [1, 2000], defaultPoolSize: [1, 100],
+  maxClientConn: [1, 2000], queryWaitTimeout: [0, 600], writeRatio: [0, 1],
+  updateRatio: [0, 1], seqScanRatio: [0, 1], sharedBuffers: [128, 65536],
+  workMem: [1, 256], checkpointTimeout: [1, 3600], checkpointCompletionTarget: [0.1, 1],
+  maxWalSize: [1, 8192], bgwriterLruMaxpages: [0, 400], autovacuumScaleFactor: [0, 1],
+  standbyANetworkLag: [0, 400], standbyBNetworkLag: [0, 400],
+  walGDownloadConcurrency: [1, 16], backupRetention: [1, 5], recoveryTargetAge: [0, 300],
+  timeScale: [0.05, 20],
+}
+const enums: Partial<Record<keyof Knobs, readonly string[]>> = {
+  poolMode: ['disabled', 'session', 'transaction', 'statement'],
+  synchronousCommit: ['off', 'local', 'remote_write', 'on', 'remote_apply'],
+  synchronousStandbyNames: ['none', 'standbyA', 'standbyB'],
+  walLevel: ['minimal', 'replica', 'logical'], recoveryTargetTimeline: ['latest', 'current'],
+  restoreDrillFault: ['none', 'empty_other_table', 'corrupt_object'],
+  haPartition: ['healthy', 'isolate_node', 'isolate_dcs_majority', 'split_dcs'],
+}
+const scenarioIds = new Set(SCENARIOS.map((scenario) => scenario.id))
+const choices = new Set(SCENARIOS.flatMap((scenario) => scenario.decision?.choices.map((choice) => choice.id) ?? []))
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid replay object')
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) throw new Error('Invalid replay prototype')
+  return value as Record<string, unknown>
+}
+
+function fields(value: Record<string, unknown>, allowed: readonly string[]): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) throw new Error(`Unknown replay field: ${key}`)
+  }
+}
+
+function integer(value: unknown, min: number, max: number, name: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`Invalid replay ${name}`)
+  }
+  return value
+}
+
+function knob(key: unknown, value: unknown): key is keyof Knobs {
+  if (typeof key !== 'string' || !Object.hasOwn(DEFAULT_KNOBS, key)) return false
+  const name = key as keyof Knobs
+  if (typeof DEFAULT_KNOBS[name] === 'boolean') return typeof value === 'boolean'
+  const range = numericBounds[name]
+  if (range) return typeof value === 'number' && Number.isFinite(value) && value >= range[0] && value <= range[1]
+  return typeof value === 'string' && enums[name]?.includes(value) === true
+}
+
+function action(value: unknown, ticks: number): ReplayAction {
+  const item = object(value)
+  const tick = integer(item.tick, 0, ticks, 'action tick')
+  switch (item.type) {
+    case 'knob':
+      fields(item, ['tick', 'type', 'key', 'value', 'source'])
+      if (!knob(item.key, item.value) || (item.source !== undefined && item.source !== 'user')) {
+        throw new Error('Invalid replay knob')
+      }
+      return { tick, type: 'knob', key: item.key, value: item.value as Knobs[keyof Knobs],
+        ...(item.source === 'user' ? { source: 'user' as const } : {}) }
+    case 'scenario':
+      fields(item, ['tick', 'type', 'id'])
+      if (item.id !== null && (typeof item.id !== 'string' || !scenarioIds.has(item.id))) {
+        throw new Error('Invalid replay scenario')
+      }
+      return { tick, type: 'scenario', id: item.id as string | null }
+    case 'decision':
+      fields(item, ['tick', 'type', 'choice'])
+      if (!choices.has(item.choice as ScenarioChoiceId)) throw new Error('Invalid replay decision')
+      return { tick, type: 'decision', choice: item.choice as ScenarioChoiceId }
+    case 'recover':
+      fields(item, ['tick', 'type'])
+      return { tick, type: 'recover' }
+    default:
+      throw new Error('Unsupported replay action')
+  }
+}
+
+function validateRecord(value: unknown): ReplayRecord {
+  const item = object(value)
+  fields(item, ['version', 'modelVersion', 'seed', 'ticks', 'steps', 'actions'])
+  if (item.version !== 1) throw new Error('Unsupported replay format version')
+  if (item.modelVersion !== REPLAY_MODEL_VERSION) throw new Error('Replay model-version mismatch')
+  const seed = integer(item.seed, 0, 0xffff_ffff, 'seed')
+  const ticks = integer(item.ticks, 0, REPLAY_MAX_TICKS, 'tick limit')
+  if (!Array.isArray(item.steps) || item.steps.length > REPLAY_MAX_TICKS) throw new Error('Replay step limit exceeded')
+  if (!Array.isArray(item.actions) || item.actions.length > REPLAY_MAX_ACTIONS) throw new Error('Replay action limit exceeded')
+  const steps: ReplayRecord['steps'] = []
+  let count = 0
+  let seconds = 0
+  for (const entry of item.steps) {
+    const run = object(entry)
+    fields(run, ['count', 'dt'])
+    const n = integer(run.count, 1, REPLAY_MAX_TICKS, 'step count')
+    if (typeof run.dt !== 'number' || !Number.isFinite(run.dt) || run.dt <= 0 || run.dt > MAX_DELTA) {
+      throw new Error('Invalid replay step duration')
+    }
+    count += n
+    seconds += n * run.dt
+    if (count > ticks || seconds > MAX_MODEL_SECONDS + 1e-7) throw new Error('Replay duration limit exceeded')
+    steps.push({ count: n, dt: run.dt })
+  }
+  if (count !== ticks) throw new Error('Replay step count does not match ticks')
+  const actions: ReplayAction[] = []
+  let previous = 0
+  for (const entry of item.actions) {
+    const parsed = action(entry, ticks)
+    if (parsed.tick < previous) throw new Error('Replay actions are out of order')
+    previous = parsed.tick
+    actions.push(parsed)
+  }
+  return { version: 1, modelVersion: REPLAY_MODEL_VERSION, seed, ticks, steps, actions }
+}
+
+export function encodeReplay(value: unknown): string {
+  const text = JSON.stringify(validateRecord(value))
+  if (text.length > REPLAY_MAX_BYTES) throw new Error('Replay share size limit exceeded')
+  return text
+}
+
+export function decodeReplay(text: string): ReplayRecord {
+  if (typeof text !== 'string' || text.length > REPLAY_MAX_BYTES) throw new Error('Replay share size limit exceeded')
+  return validateRecord(JSON.parse(text))
+}
+
+/** Attach to a fresh model before consumers capture its methods (timebase/UI). */
+export function createIncidentReplay(
+  sim: SimApi,
+  bus: Bus,
+  options: { seed?: number; onChange?: () => void } = {},
+) {
+  const configuration = simulationReplayConfiguration(sim)
+  const seed = configuration?.seed
+  if (seed === undefined || (options.seed !== undefined && options.seed !== seed)) {
+    throw new Error('Replay seed does not match the model instance')
+  }
+  if (!configuration?.standard) throw new Error('Unsupported replay model configuration')
+  if (attached.has(sim) || attachedBuses.has(bus)) throw new Error('Replay is already attached')
+  if (sim.state.realT !== 0) throw new Error('Replay must attach before the first model update')
+  attached.add(sim)
+  attachedBuses.add(bus)
+  const original = { ...sim }
+  const originalEmit = bus.emit
+  const durations = new Float64Array(REPLAY_MAX_TICKS)
+  const log: ReplayAction[] = []
+  const status: ReplayStatus = {
+    tick: 0, actionCount: 0, totalTicks: 0, valid: true, reason: '', seeking: false, seekProgress: 0,
+  }
+  let elapsed = 0
+  let originTime = sim.state.t
+  let busy = 0
+  let disposed = false
+  let baseline: ReplayOutcome | null = null
+  const restoredListeners = new Set<() => void>()
+
+  function notify(): void { options.onChange?.() }
+  function invalidate(reason: string): void {
+    if (!status.valid) return
+    status.valid = false
+    status.reason = reason
+    notify()
+  }
+  function requireReady(): void {
+    if (disposed) throw new Error('Replay controller is disposed')
+    if (status.seeking) throw new Error('Cannot change the model while seeking a replay')
+  }
+  function requireValid(): void {
+    requireReady()
+    if (!status.valid) throw new Error(status.reason)
+  }
+  function branch(): void {
+    log.length = status.actionCount
+    status.totalTicks = status.tick
+  }
+  function record(next: ReplayAction): void {
+    if (!status.valid) return
+    branch()
+    if (log.length >= REPLAY_MAX_ACTIONS) {
+      invalidate('Replay action limit reached; reset to record another incident')
+      return
+    }
+    log.push(next)
+    status.actionCount = log.length
+    notify()
+  }
+  function invoke<T>(next: ReplayAction, execute: () => T): T {
+    requireReady()
+    record(action(next, status.tick))
+    busy++
+    try { return execute() } finally { busy-- }
+  }
+  function apply(next: ReplayAction): void {
+    switch (next.type) {
+      case 'knob': original.setKnob(next.key, next.value, next.source); break
+      case 'scenario': original.runScenario(next.id); break
+      case 'decision': original.chooseScenario(next.choice); break
+      case 'recover': original.recoverScenario(); break
+    }
+  }
+  function outcome(): ReplayOutcome {
+    const state = sim.state
+    let deadTuples = 0
+    let tablePages = 0
+    let retainedWalBytes = 0
+    for (const table of state.tables) { deadTuples += table.deadTuples; tablePages += table.pages }
+    // Both slots retain overlapping suffixes of the same WAL stream.
+    for (const slot of state.replication.physicalSlots) retainedWalBytes = Math.max(retainedWalBytes, slot.retainedBytes)
+    return {
+      elapsedTicks: status.tick, elapsedModelSeconds: state.t - originTime, scenario: state.scenario,
+      commits: state.stats.commits, rollbacks: state.stats.rollbacks, throughputTps: state.stats.tps,
+      latencyP99ModelMs: state.stats.latency.p99.totalMs, deadTuples, tablePages,
+      reclaimedTuples: state.autovac.landfill, retainedWalBytes,
+      rejectedWrites: state.disasterRecovery.archive.rejectedWrites,
+      lostTransactions: state.highAvailability.transition.lossTransactions,
+    }
+  }
+
+  sim.update = (dt: number): void => {
+    if (status.seeking) return
+    if (Number.isFinite(dt) && dt > 0 && !sim.state.knobs.paused) {
+      if (status.valid) {
+        branch()
+        if (status.tick >= REPLAY_MAX_TICKS || dt > MAX_DELTA || elapsed + dt > MAX_MODEL_SECONDS + 1e-7) {
+          invalidate('Replay duration limit reached; reset to record another incident')
+        } else {
+          durations[status.tick] = dt
+          elapsed += dt
+          status.totalTicks++
+        }
+      }
+      status.tick++
+    }
+    busy++
+    try { original.update(dt) } finally { busy-- }
+  }
+  sim.setKnob = (key, value, source) => invoke(
+    { tick: status.tick, type: 'knob', key, value, ...(source ? { source } : {}) },
+    () => original.setKnob(key, value, source),
+  )
+  sim.runScenario = (id) => invoke({ tick: status.tick, type: 'scenario', id }, () => original.runScenario(id))
+  sim.chooseScenario = (choice) => invoke({ tick: status.tick, type: 'decision', choice }, () => original.chooseScenario(choice))
+  sim.recoverScenario = () => invoke({ tick: status.tick, type: 'recover' }, () => original.recoverScenario())
+
+  bus.emit = <K extends keyof BusEvents>(type: K, payload: BusEvents[K]): void => {
+    if (status.seeking && (type === 'flow' || type === 'toast' || type === 'narrate' || type === 'focus')) return
+    if (!busy && (type === 'knob' || type === 'scenario')) {
+      const next = type === 'knob'
+        ? { tick: status.tick, type: 'knob', ...(payload as BusEvents['knob']) }
+        : { tick: status.tick, type: 'scenario', ...(payload as BusEvents['scenario']) }
+      requireReady()
+      // The bus ignores a repeated scenario; a direct runScenario restarts it.
+      if (type !== 'scenario' || (payload as BusEvents['scenario']).id !== sim.state.scenario) {
+        record(action(next, status.tick))
+      }
+      busy++
+      try { originalEmit(type, payload) } finally { busy-- }
+      return
+    }
+    originalEmit(type, payload)
+  }
+
+  const unsupported = [
+    'request', 'setTraceMode', 'endTrace', 'startBaseBackup', 'startPointInTimeRestore',
+    'startRestoreDrill', 'setLeaderOpinion', 'startSwitchover', 'startFailover', 'startPgRewind',
+  ] as const
+  for (const method of unsupported) {
+    const raw = original[method] as (...args: unknown[]) => unknown
+    ;(sim as unknown as Record<string, unknown>)[method] = (...args: unknown[]) => {
+      requireReady()
+      invalidate(`Unsupported replay action: ${method}; reset to record another incident`)
+      busy++
+      try { return raw(...args) } finally { busy-- }
+    }
+  }
+
+  function reset(): void {
+    requireReady()
+    log.length = 0
+    status.tick = status.totalTicks = status.actionCount = 0
+    status.valid = true
+    status.reason = ''
+    status.seekProgress = 0
+    elapsed = 0
+    baseline = null
+    busy++
+    try { original.reset() } finally { busy-- }
+    originTime = sim.state.t
+    notify()
+  }
+  sim.reset = reset
+
+  function pointAt(value: number | ReplayPoint): ReplayPoint {
+    const tick = integer(typeof value === 'number' ? value : value.tick, 0, status.totalTicks, 'rewind tick')
+    let actionCount = 0
+    while (actionCount < log.length && log[actionCount].tick <= tick) actionCount++
+    if (typeof value !== 'number') {
+      actionCount = integer(value.actionCount, 0, actionCount, 'checkpoint action count')
+      if (actionCount < log.length && log[actionCount].tick < tick) throw new Error('Invalid replay checkpoint order')
+    }
+    return { tick, actionCount }
+  }
+
+  async function seek(target: ReplayPoint): Promise<void> {
+    status.seeking = true
+    status.seekProgress = 0
+    notify()
+    busy++
+    try {
+      original.reset()
+      originTime = sim.state.t
+      elapsed = 0
+      let at = 0
+      for (let tick = 0; tick <= target.tick; tick++) {
+        if (disposed) throw new Error('Replay controller was disposed during rewind')
+        while (at < target.actionCount && log[at].tick === tick) apply(log[at++])
+        if (tick === target.tick) break
+        original.update(durations[tick])
+        elapsed += durations[tick]
+        status.seekProgress = (tick + 1) / Math.max(1, target.tick)
+        if ((tick + 1) % SEEK_BATCH === 0) await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      }
+      status.tick = target.tick
+      status.actionCount = target.actionCount
+      status.seekProgress = 1
+      originalEmit('sim:reset', {})
+    } catch (error) {
+      invalidate('Replay reconstruction failed; reset before recording again')
+      throw error
+    } finally {
+      busy--
+      status.seeking = false
+      notify()
+    }
+    for (const listener of restoredListeners) listener()
+  }
+
+  return {
+    status: status as Readonly<ReplayStatus>,
+    onRestored(listener: () => void): () => void {
+      restoredListeners.add(listener)
+      return () => { restoredListeners.delete(listener) }
+    },
+    checkpoint: (): ReplayPoint => ({ tick: status.tick, actionCount: status.actionCount }),
+    async rewind(value: number | ReplayPoint): Promise<void> {
+      requireValid()
+      const target = pointAt(value)
+      baseline = outcome()
+      await seek(target)
+    },
+    compare(): { baseline: ReplayOutcome; current: ReplayOutcome; sameDuration: boolean } | null {
+      if (!baseline) return null
+      const current = outcome()
+      return { baseline: { ...baseline }, current,
+        sameDuration: Math.abs(baseline.elapsedModelSeconds - current.elapsedModelSeconds) < 1e-7 }
+    },
+    exportRecord(): ReplayRecord {
+      requireValid()
+      const steps: ReplayRecord['steps'] = []
+      for (let tick = 0; tick < status.tick; tick++) {
+        const previous = steps[steps.length - 1]
+        if (previous && previous.dt === durations[tick]) previous.count++
+        else steps.push({ count: 1, dt: durations[tick] })
+      }
+      const record: ReplayRecord = {
+        version: 1, modelVersion: REPLAY_MODEL_VERSION, seed, ticks: status.tick, steps,
+        actions: log.slice(0, status.actionCount).map((entry) => ({ ...entry })),
+      }
+      encodeReplay(record)
+      return record
+    },
+    async loadRecord(value: unknown): Promise<void> {
+      requireReady()
+      const record = decodeReplay(encodeReplay(value))
+      if (record.seed !== seed) throw new Error('Replay seed does not match this model instance')
+      let tick = 0
+      for (const run of record.steps) {
+        durations.fill(run.dt, tick, tick + run.count)
+        tick += run.count
+      }
+      log.length = 0
+      log.push(...record.actions)
+      status.valid = true
+      status.reason = ''
+      status.totalTicks = record.ticks
+      baseline = null
+      await seek({ tick: record.ticks, actionCount: log.length })
+    },
+    reset,
+    dispose(): void {
+      disposed = true
+      restoredListeners.clear()
+      Object.assign(sim, original)
+      bus.emit = originalEmit
+      attached.delete(sim)
+      attachedBuses.delete(bus)
+    },
+  }
+}
+
+export type IncidentReplay = ReturnType<typeof createIncidentReplay>

--- a/src/styles/replay-panel.css
+++ b/src/styles/replay-panel.css
@@ -1,0 +1,38 @@
+.pg-replay {
+  position: fixed;
+  z-index: 110;
+  top: max(100px, 14vh);
+  right: 16px;
+  width: min(460px, calc(100vw - 32px));
+  max-height: calc(86vh - 20px);
+  overflow: auto;
+  padding: 20px;
+  border: 1px solid var(--line-hard);
+  border-radius: 16px;
+  background: var(--bg-panel-solid);
+  color: var(--ink);
+  box-shadow: 0 16px 50px #0006;
+  font-size: 13px;
+  line-height: 1.5;
+  pointer-events: auto;
+  box-sizing: border-box;
+}
+.pg-replay[hidden] { display: none; }
+.pg-replay__heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.pg-replay h2 { margin: 0; font-size: 20px; }
+.pg-replay h3 { font-size: 15px; }
+.pg-replay__disclosure { padding: 10px; border: 1px solid currentColor; border-radius: 8px; }
+.pg-replay__actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.pg-replay .pg-btn { min-height: 38px; white-space: normal; }
+.pg-replay button:disabled { opacity: .5; cursor: not-allowed; }
+.pg-replay summary { cursor: pointer; padding: 12px 0; }
+.pg-replay__record { display: block; box-sizing: border-box; width: 100%; margin: 12px 0; padding: 8px; color: inherit; background: transparent; border: 1px solid currentColor; font: 11px monospace; resize: vertical; }
+.pg-replay__confirm { display: flex; gap: 8px; align-items: flex-start; margin: 12px 0; }
+.pg-replay__comparison table { border-collapse: collapse; width: 100%; font-size: 12px; }
+.pg-replay__comparison th, .pg-replay__comparison td { padding: 6px 4px; text-align: right; vertical-align: top; border-bottom: 1px solid var(--line-hard); }
+.pg-replay__comparison th:first-child { text-align: left; }
+.pg-replay__message:empty { display: none; }
+@media (max-width: 600px) {
+  .pg-replay { top: 80px; right: 8px; width: calc(100vw - 16px); max-height: calc(100dvh - 96px); padding: 14px; }
+  .pg-replay__actions { flex-direction: column; }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -340,7 +340,7 @@ function vitalHistory(key: VitalKey, s: SimState): number[] {
  * FACTORY
  * ========================================================================*/
 
-export function createHud(ctx: UiContext): UiModule {
+export function createHud(ctx: UiContext, options: { onReplay?: () => void } = {}): UiModule {
   const bus = ctx.bus
   const looseBus = bus
   const sim = ctx.sim
@@ -494,6 +494,11 @@ export function createHud(ctx: UiContext): UiModule {
     icon('tour', 15),
     el('span', { text: 'Tour' }),
   )
+  const replayBtn = options.onReplay ? el('button', {
+    class: 'pg-btn hud-tool hud-replay', type: 'button', text: 'Replay',
+    title: 'Save a checkpoint, rewind, and compare model decisions',
+    'aria-label': 'Rewind and compare model incidents', on: { click: options.onReplay },
+  }) : null
   const traceBtn = el(
     'button',
     {
@@ -656,6 +661,7 @@ export function createHud(ctx: UiContext): UiModule {
     legalBtn,
     viewBtn,
     tourBtn,
+    replayBtn,
     traceBtn,
     diagnoseLink,
     walkBtn,

--- a/src/ui/latency-hud.test.ts
+++ b/src/ui/latency-hud.test.ts
@@ -28,6 +28,15 @@ function context(): UiContext {
 }
 
 describe('latency HUD', () => {
+  it('opens the incident replay controls', () => {
+    const replay = vi.fn()
+    const hud = createHud(context(), { onReplay: replay })
+    const button = document.querySelector<HTMLButtonElement>('.hud-replay')!
+    expect(button.getAttribute('aria-label')).toBe('Rewind and compare model incidents')
+    button.click()
+    expect(replay).toHaveBeenCalledTimes(1)
+    hud.dispose()
+  })
   beforeEach(() => {
     vi.useFakeTimers()
     const dom = installTestDom()

--- a/src/ui/replay-panel.test.ts
+++ b/src/ui/replay-panel.test.ts
@@ -55,5 +55,6 @@ describe('incident replay panel', () => {
     expect(replay.compare()?.sameDuration).toBe(true)
     expect(document.body.textContent).toContain('Same model duration')
     expect(document.body.textContent).toContain('PGlite results are separate')
+    expect(document.body.textContent).toContain('Counters and current gauges')
   })
 })

--- a/src/ui/replay-panel.test.ts
+++ b/src/ui/replay-panel.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { installTestDom } from '../../test/dom'
+import { createBus } from '../core/bus'
+import { createSim } from '../sim/model'
+import { createIncidentReplay, encodeReplay } from '../sim/replay'
+import { createReplayPanel } from './replay-panel'
+import type { UiContext } from './uikit'
+
+const cleanups: (() => void)[] = []
+afterEach(() => { while (cleanups.length) cleanups.pop()!() })
+function setup() {
+  installTestDom()
+  const bus = createBus()
+  const sim = createSim(bus)
+  const replay = createIncidentReplay(sim, bus)
+  const panel = createReplayPanel({ bus, sim } as UiContext, replay)
+  cleanups.push(() => { panel.dispose(); replay.dispose() })
+  panel.open()
+  return { sim, replay, panel }
+}
+
+describe('incident replay panel', () => {
+  it('saves a genuine checkpoint and reconstructs that state after later work', async () => {
+    const { sim, panel } = setup()
+    sim.setKnob('workMem', 64)
+    sim.update(1 / 30)
+    panel.captureCheckpoint()
+    const expected = structuredClone(sim.state)
+    sim.setKnob('workMem', 8)
+    sim.update(1 / 30)
+    await panel.rewindCheckpoint()
+    expect(sim.state).toEqual(expected)
+    expect(document.body.textContent).toContain('not PostgreSQL measurements')
+  })
+
+  it('refuses imports unless replacing the incident is explicitly confirmed', async () => {
+    const { sim, replay, panel } = setup()
+    const record = encodeReplay(replay.exportRecord())
+    sim.update(1 / 30)
+    const expected = structuredClone(sim.state)
+    await expect(panel.importRecord(record, false)).rejects.toThrow(/confirm/i)
+    expect(sim.state).toEqual(expected)
+    await panel.importRecord(record, true)
+    expect(replay.status.tick).toBe(0)
+    expect(panel.hasCheckpoint()).toBe(false)
+  })
+
+  it('makes an exact-duration comparison without describing it as measured PostgreSQL', async () => {
+    const { sim, panel, replay } = setup()
+    panel.captureCheckpoint()
+    sim.update(1 / 30)
+    await panel.rewindCheckpoint()
+    sim.setKnob('workMem', 64)
+    await panel.runComparison()
+    expect(replay.compare()?.sameDuration).toBe(true)
+    expect(document.body.textContent).toContain('Same model duration')
+    expect(document.body.textContent).toContain('PGlite results are separate')
+  })
+})

--- a/src/ui/replay-panel.ts
+++ b/src/ui/replay-panel.ts
@@ -138,7 +138,7 @@ export function createReplayPanel(ctx: UiContext, replay: IncidentReplay): Repla
       body.append(el('tr', {}, el('th', { text: label, scope: 'row' }), el('td', { text: format(result.baseline[key]) }), el('td', { text: format(result.current[key]) })))
     }
     table.append(body)
-    comparison.append(table, el('p', { text: 'Counts are cumulative from the same seeded warm model, not production capacity estimates. Reusable table space is not a promise that ordinary VACUUM shrinks a relation file.' }))
+    comparison.append(table, el('p', { text: 'Counters and current gauges are model outputs, not production capacity estimates. Both branches start from the same seeded warm model. Reusable table space is not a promise that ordinary VACUUM shrinks a relation file.' }))
   }
   function open(): void {
     returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null

--- a/src/ui/replay-panel.ts
+++ b/src/ui/replay-panel.ts
@@ -67,7 +67,7 @@ export function createReplayPanel(ctx: UiContext, replay: IncidentReplay): Repla
   el('div', { class: 'pg-replay__actions' }, save, rewind, run),
   comparison, message,
   el('details', {}, el('summary', { text: 'Share or import a local replay' }),
-    el('p', { text: 'Records contain a version, seed, elapsed steps, and allowlisted model actions. Limits: 10 model minutes, 18,000 steps, 1,024 actions, 96 KiB. Only this exact model build and seed can import them. No SQL, lesson answers, or PGlite data are included.' }),
+    el('p', { text: 'Records contain a version, seed, elapsed steps, and allowlisted model actions. Limits: 30 model minutes, 54,000 steps, 1,024 actions, 96 KiB. Only this exact model build and seed can import them. No SQL, lesson answers, or PGlite data are included.' }),
     exportButton, shareText,
     el('label', { class: 'pg-replay__confirm' }, confirm, ' I confirm that import will replace the current model incident.'),
     importButton),
@@ -75,7 +75,7 @@ export function createReplayPanel(ctx: UiContext, replay: IncidentReplay): Repla
   document.body.append(panel)
 
   function captureCheckpoint(): void {
-    if (!replay.status.valid || replay.status.seeking) throw new Error(replay.status.reason || 'Wait for replay to finish')
+    if (!replay.status.valid || replay.status.seeking || replay.status.advancing) throw new Error(replay.status.reason || 'Wait for replay to finish')
     checkpoint = replay.checkpoint()
     render()
   }
@@ -111,11 +111,11 @@ export function createReplayPanel(ctx: UiContext, replay: IncidentReplay): Repla
   let comparisonSignature = ''
   function render(): void {
     const state = replay.status
-    setText(status, state.seeking ? `Reconstructing model: ${Math.round(state.seekProgress * 100)}%`
+    setText(status, state.advancing ? 'Advancing the fixed-step model; recording every step.' : state.seeking ? `Reconstructing model: ${Math.round(state.seekProgress * 100)}%`
       : state.valid ? `Recorded ${state.tick} steps and ${state.actionCount} actions.` : `Recording unavailable: ${state.reason}`)
     setText(checkpointText, checkpoint ? `Checkpoint: step ${checkpoint.tick}, after action ${checkpoint.actionCount}.`
       : 'No checkpoint saved yet. A ready operator decision also saves one automatically.')
-    for (const control of controls) control.disabled = state.seeking
+    for (const control of controls) control.disabled = state.seeking || state.advancing
     save.disabled ||= !state.valid
     rewind.disabled ||= !state.valid || !checkpoint
     exportButton.disabled ||= !state.valid

--- a/src/ui/replay-panel.ts
+++ b/src/ui/replay-panel.ts
@@ -1,0 +1,183 @@
+import type { ScenarioDecisionState } from '../core/types'
+import { decodeReplay, encodeReplay, REPLAY_MAX_BYTES } from '../sim/replay'
+import type { IncidentReplay, ReplayPoint, ReplayOutcome } from '../sim/replay'
+import { el, setText } from './uikit'
+import type { UiContext, UiModule } from './uikit'
+import '../styles/replay-panel.css'
+
+export interface ReplayPanel extends UiModule {
+  open(): void
+  close(): void
+  captureCheckpoint(): void
+  hasCheckpoint(): boolean
+  rewindCheckpoint(): Promise<void>
+  runComparison(): Promise<void>
+  importRecord(text: string, confirmed: boolean): Promise<void>
+}
+
+/** A local model notebook: never uploads records or treats them as PGlite evidence. */
+export function createReplayPanel(ctx: UiContext, replay: IncidentReplay): ReplayPanel {
+  let checkpoint: ReplayPoint | null = null
+  let decision: ScenarioDecisionState | null = null
+  let visible = false
+  let clock = 0
+  let returnFocus: HTMLElement | null = null
+  const heading = el('h2', { text: 'Rewind an incident', id: 'replay-heading' })
+  const message = el('p', { class: 'pg-replay__message', role: 'status', 'aria-live': 'polite' })
+  const status = el('p', { class: 'pg-replay__status' })
+  const checkpointText = el('p', { class: 'pg-replay__checkpoint', text: 'No checkpoint saved yet.' })
+  const comparison = el('div', { class: 'pg-replay__comparison' })
+  const shareText = el('textarea', {
+    class: 'pg-replay__record', 'aria-label': 'Local incident record JSON', spellcheck: false,
+    maxLength: REPLAY_MAX_BYTES, rows: 5,
+  })
+  const confirm = el('input', { type: 'checkbox' })
+  const controls: HTMLButtonElement[] = []
+  function button(text: string, action: () => void | Promise<void>): HTMLButtonElement {
+    const node = el('button', { type: 'button', class: 'pg-btn', text })
+    node.addEventListener('click', () => {
+      setText(message, '')
+      Promise.resolve().then(action).catch((error: unknown) => {
+        setText(message, error instanceof Error ? error.message : 'The replay action failed.')
+      }).finally(render)
+    })
+    controls.push(node)
+    return node
+  }
+
+  const save = button('Save checkpoint', captureCheckpoint)
+  const rewind = button('Rewind to checkpoint', rewindCheckpoint)
+  const run = button('Run alternative to same duration', runComparison)
+  const exportButton = button('Prepare record to copy', () => {
+    shareText.value = encodeReplay(replay.exportRecord())
+    shareText.focus()
+    shareText.select()
+    setText(message, 'Record prepared locally. Copy it to share; nothing was uploaded.')
+  })
+  const importButton = button('Import and replace incident', () => importRecord(shareText.value, confirm.checked))
+  const closeButton = el('button', { type: 'button', class: 'pg-btn', text: 'Close', 'aria-label': 'Close incident replay' })
+  closeButton.addEventListener('click', close)
+  const panel = el('section', {
+    class: 'pg-replay', role: 'dialog', 'aria-labelledby': 'replay-heading', hidden: true,
+  },
+  el('div', { class: 'pg-replay__heading' }, heading, closeButton),
+  el('p', { class: 'pg-replay__disclosure', data: { disclosure: 'model' }, text: 'Scaled model outcomes, not PostgreSQL measurements. PGlite results are separate. Replaying does not operate a real database.' }),
+  el('p', { text: 'Save a checkpoint before an intervention. Try one choice and observe its outcome, then rewind, change your choice, and compare after the same model duration.' }),
+  status, checkpointText,
+  el('div', { class: 'pg-replay__actions' }, save, rewind, run),
+  comparison, message,
+  el('details', {}, el('summary', { text: 'Share or import a local replay' }),
+    el('p', { text: 'Records contain a version, seed, elapsed steps, and allowlisted model actions. Limits: 10 model minutes, 18,000 steps, 1,024 actions, 96 KiB. Only this exact model build and seed can import them. No SQL, lesson answers, or PGlite data are included.' }),
+    exportButton, shareText,
+    el('label', { class: 'pg-replay__confirm' }, confirm, ' I confirm that import will replace the current model incident.'),
+    importButton),
+  )
+  document.body.append(panel)
+
+  function captureCheckpoint(): void {
+    if (!replay.status.valid || replay.status.seeking) throw new Error(replay.status.reason || 'Wait for replay to finish')
+    checkpoint = replay.checkpoint()
+    render()
+  }
+  async function rewindCheckpoint(): Promise<void> {
+    if (!checkpoint) throw new Error('Save a checkpoint before rewinding')
+    await replay.rewind(checkpoint)
+    setText(message, 'Checkpoint restored. Choose a different intervention, then run the alternative to the same duration.')
+    render()
+  }
+  async function runComparison(): Promise<void> {
+    await replay.runToComparison()
+    setText(message, 'The alternative is paused at the original branch’s model duration. Compare the outcomes below.')
+    render()
+  }
+  async function importRecord(text: string, confirmed: boolean): Promise<void> {
+    if (!confirmed) throw new Error('Confirm replacement of the current incident before importing')
+    const record = decodeReplay(text)
+    await replay.loadRecord(record)
+    checkpoint = null
+    decision = ctx.sim.state.scenarioDecision
+    confirm.checked = false
+    setText(message, 'Local replay imported. Save a new checkpoint before another intervention.')
+    render()
+  }
+
+  const metrics: readonly [keyof ReplayOutcome, string, string][] = [
+    ['commits', 'Commits', ''], ['rollbacks', 'Rollbacks', ''],
+    ['latencyP99ModelMs', 'p99 latency', ' model ms'],
+    ['deadTuples', 'Dead tuples', ''], ['tablePages', 'Table pages', ''],
+    ['reclaimedTuples', 'Tuples reclaimed', ''], ['retainedWalBytes', 'WAL retained by physical slots', ' bytes'],
+    ['rejectedWrites', 'Rejected writes', ''], ['lostTransactions', 'Lost transactions', ''],
+  ]
+  let comparisonSignature = ''
+  function render(): void {
+    const state = replay.status
+    setText(status, state.seeking ? `Reconstructing model: ${Math.round(state.seekProgress * 100)}%`
+      : state.valid ? `Recorded ${state.tick} steps and ${state.actionCount} actions.` : `Recording unavailable: ${state.reason}`)
+    setText(checkpointText, checkpoint ? `Checkpoint: step ${checkpoint.tick}, after action ${checkpoint.actionCount}.`
+      : 'No checkpoint saved yet. A ready operator decision also saves one automatically.')
+    for (const control of controls) control.disabled = state.seeking
+    save.disabled ||= !state.valid
+    rewind.disabled ||= !state.valid || !checkpoint
+    exportButton.disabled ||= !state.valid
+    const result = replay.compare()
+    run.disabled ||= !state.valid || !result || result.current.elapsedModelSeconds > result.baseline.elapsedModelSeconds + 1e-7
+    if (!visible) return
+    const signature = JSON.stringify(result)
+    if (signature === comparisonSignature) return
+    comparisonSignature = signature
+    comparison.replaceChildren()
+    if (!result) return
+    comparison.append(el('h3', { text: result.sameDuration ? 'Same model duration' : 'Different model durations — not yet a controlled comparison' }),
+      el('p', { text: `Original: ${result.baseline.elapsedModelSeconds.toFixed(2)} model seconds. Alternative: ${result.current.elapsedModelSeconds.toFixed(2)} model seconds. Same seed and checkpoint; only your subsequent actions differ.` }))
+    if (!result.sameDuration) return
+    const table = el('table', {}, el('thead', {}, el('tr', {}, el('th', { text: 'Model outcome', scope: 'col' }),
+      el('th', { text: 'Original', scope: 'col' }), el('th', { text: 'Alternative', scope: 'col' }))))
+    const body = el('tbody')
+    for (const [key, label, unit] of metrics) {
+      const format = (value: ReplayOutcome[typeof key]): string => `${typeof value === 'number' ? value.toLocaleString('en-US', { maximumFractionDigits: 2 }) : value}${unit}`
+      body.append(el('tr', {}, el('th', { text: label, scope: 'row' }), el('td', { text: format(result.baseline[key]) }), el('td', { text: format(result.current[key]) })))
+    }
+    table.append(body)
+    comparison.append(table, el('p', { text: 'Counts are cumulative from the same seeded warm model, not production capacity estimates. Reusable table space is not a promise that ordinary VACUUM shrinks a relation file.' }))
+  }
+  function open(): void {
+    returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    visible = true
+    panel.hidden = false
+    render()
+    closeButton.focus()
+  }
+  function close(): void {
+    visible = false
+    panel.hidden = true
+    returnFocus?.focus()
+  }
+  const onKey = (event: KeyboardEvent): void => {
+    if (visible && event.key === 'Escape') { event.stopPropagation(); close() }
+  }
+  panel.addEventListener('keydown', onKey)
+  const offReset = ctx.bus.on('sim:reset', () => {
+    if (replay.status.seeking) return
+    checkpoint = null
+    decision = null
+    render()
+  })
+  return {
+    open, close, captureCheckpoint, hasCheckpoint: () => checkpoint !== null,
+    rewindCheckpoint, runComparison, importRecord,
+    update(dt): void {
+      if (!replay.status.seeking) {
+        const current = ctx.sim.state.scenarioDecision
+        if (current && current !== decision && current.phase === 'ready' && replay.status.valid) {
+          checkpoint = replay.checkpoint()
+          decision = current
+        }
+      }
+      clock += dt
+      if (clock < 0.25) return
+      clock = 0
+      if (visible) render()
+    },
+    dispose(): void { offReset(); panel.removeEventListener('keydown', onKey); panel.remove() },
+  }
+}

--- a/test/corrections.browser.test.ts
+++ b/test/corrections.browser.test.ts
@@ -222,11 +222,13 @@ describe('PostgreSQL correction reports', () => {
         }
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
       })()`,
       prepare: `(() => {
         const { sim, bus } = window.PGSIMCITY
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
         sim.setKnob('recoveryTargetAge', 40)
         sim.setKnob('walGDownloadConcurrency', 4)
         Object.assign(sim.state.disasterRecovery.drill, {


### PR DESCRIPTION
## Summary
Versioned, bounded simulation replay with reproducible initialization, ordered actions, decision checkpoints, asynchronous rewind and comparison support. Unsupported mutations invalidate recording explicitly rather than exporting a misleading history.

Part of #15 / #10. Engine commit c7d7020.

## Verification and remaining gates
40 focused tests, typecheck and build passed. Tests exposed and corrected both reset-state drift and repeated-scenario replay divergence.

**Draft:** the replay/comparison UI and app wiring are in progress. Full candidate tests, adversarial replay-input review, and actual browser comparison are required before review-ready status. No complete linked City/Diagnose/Machine journey or shipped replay feature is claimed from the engine alone.