### PR TITLE
feat: add an opt-in WebGPU renderer lab

### DIFF
--- a/docs/webgpu-lab.md
+++ b/docs/webgpu-lab.md
@@ -1,0 +1,58 @@
+# Renderer lab
+
+Open `experimental/webgpu/` and select **Start renderer experiment**. This
+secondary entry is isolated from the city: visiting the city does not import
+the experiment, and visiting the experiment does not initialize a renderer
+until requested. The ordinary city remains the supported experience.
+
+The lab renders a frozen warm-state buffer sample from the real simulation,
+using the city's tile coordinates and palette. It is a material and backend
+study, not a replacement district or a new teaching model. A fresh page uses
+the same model seed, camera, sample, resolution policy and light. Select
+**Force WebGL2 comparison** before starting to compare the node renderer's
+backends. That is not the existing `WebGLRenderer` pipeline.
+
+## Supported and missing
+
+The current pipeline uses `MeshStandardNodeMaterial`, instanced frame columns,
+directional shadow mapping, ACES tone mapping and MSAA. The WebGPU renderer
+selects its WebGL2 backend when WebGPU is unavailable; initialization failure
+keeps navigation back to the supported city visible.
+
+There is no feature parity claim. City architecture, moving mechanisms,
+interaction, semantic bloom, water reflection, baked transfer, GTAO, SSGI and
+temporal antialiasing are not ported. Existing custom shader materials,
+`onBeforeCompile` hooks and `EffectComposer` cannot simply be passed into this
+renderer. Their mechanisms need node/TSL equivalents before a default switch.
+See the official [migration guide](https://threejs.org/manual/en/webgpurenderer)
+and [post-processing guide](https://threejs.org/manual/en/webgpu-postprocessing.html).
+
+## Measurement protocol and adoption gate
+
+The local report includes actual selected backend, first-frame startup time,
+one-second presentation-interval windows, full-frame draw counts, triangles,
+canvas resolution and the renderer's estimated memory. Presentation intervals
+include browser scheduling and CPU work; they are not GPU timestamps. Renderer
+memory is not whole-device memory. No hardware identity is collected and no
+report is transmitted.
+
+Before considering adoption:
+
+1. Record named desktop and mobile hardware, OS/browser, power state, viewport,
+   pixel ratio and selected backend. Keep thermal state and test settings fixed.
+2. Capture the same frozen view on both backends. Review semantic colors,
+   shadow artifacts, edges and material appearance, not only average FPS.
+3. Capture cold startup and at least 30 steady-state report windows after
+   shader warmup. Record median and worst windows; repeat after resizing and
+   background/foreground transitions. Test unsupported WebGPU and initialization
+   failure. Software screenshots prove rendering only, not hardware performance.
+4. Add one migrated effect at a time, starting with temporal AA and SSGI;
+   measure image stability, ghosting and cost. Do not enable an effect merely
+   because an official demo looks good on another scene.
+5. Compare against the complete supported city at equivalent quality. Require
+   semantic parity, acceptable memory/startup, and useful frame times on named
+   devices. 60 fps desktop and 30 fps mobile are targets, not achieved results.
+
+Until that evidence exists, the decision is **no default renderer migration**.
+The lab is the operational starting point for issue #17, not its completed
+premium-graphics acceptance gate.

--- a/experimental/webgpu/index.html
+++ b/experimental/webgpu/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Renderer lab · PGSimCity</title></head>
+<body>
+  <main>
+    <a href="../../">← Return to the complete city</a>
+    <h1>Renderer lab</h1>
+    <p>Experimental buffer pool (<code>shared_buffers</code>) material study. Not the complete city or a PostgreSQL measurement.</p>
+    <p>Same frozen, seeded model sample and camera on both backends. Color: clean blue, dirty red, pinned amber (takes precedence), unused dark. Column height represents scaled <code>usage_count</code>, not bytes.</p>
+    <div class="controls"><label>Backend <select id="backend"><option value="auto">WebGPU, with WebGL2 fallback</option><option value="webgl2">Force WebGL2 comparison</option></select></label><button id="start">Start renderer experiment</button></div>
+    <p id="status" role="status">No renderer loaded. Requires WebGPU or WebGL2. Start-up failure leaves the complete city link available.</p>
+    <div id="viewport" aria-label="Representative buffer frame material study"></div>
+    <pre id="report" aria-label="Local performance report">No measurements yet.</pre>
+    <p>Frame intervals are wall-clock presentation intervals, not GPU execution times. Renderer memory is an estimate, not total device memory. No device identifiers or measurements are sent anywhere.</p>
+    <p>Supported: node-based physical material, instanced sample columns, directional shadows, MSAA. Missing: city architecture, animation, interaction, semantic bloom, water, indirect lighting, SSGI and temporal antialiasing. This experiment does not establish quality parity or a speedup.</p>
+  </main>
+  <script type="module" src="../../src/experimental/webgpu/main.ts"></script>
+</body>
+</html>

--- a/src/experimental/webgpu/main.ts
+++ b/src/experimental/webgpu/main.ts
@@ -1,0 +1,20 @@
+import { createLabSession } from './session'
+import './style.css'
+
+const start = document.querySelector<HTMLButtonElement>('#start')!
+const backend = document.querySelector<HTMLSelectElement>('#backend')!
+const status = document.querySelector<HTMLElement>('#status')!
+const session = createLabSession(async () => {
+  const { startPrototype } = await import('./prototype')
+  return startPrototype(document.querySelector('#viewport')!, document.querySelector('#report')!, backend.value === 'webgl2')
+})
+start.addEventListener('click', async () => {
+  start.disabled = true
+  backend.disabled = true
+  status.textContent = 'Initializing renderer…'
+  await session.start()
+  const state = session.state()
+  status.textContent = state.status === 'ready'
+    ? `Active backend: ${state.backend}. Reload this page to compare the other backend.`
+    : 'Renderer unavailable. Return to the complete city using the link above; it has its own WebGL2 support check.'
+})

--- a/src/experimental/webgpu/prototype.ts
+++ b/src/experimental/webgpu/prototype.ts
@@ -1,0 +1,121 @@
+import * as THREE from 'three/webgpu'
+import { createBus } from '../../core/bus'
+import { frameAppearance } from './sample'
+import { createSim } from '../../sim/model'
+import { CITY, bufferTilePos } from '../../world/layout'
+import type { Backend } from './session'
+
+export async function startPrototype(host: HTMLElement, report: HTMLElement, forceWebGL: boolean): Promise<Backend> {
+  const started = performance.now()
+  const renderer = new THREE.WebGPURenderer({ antialias: true, forceWebGL })
+  const geometries: THREE.BufferGeometry[] = []
+  const materials: THREE.Material[] = []
+  let observer: ResizeObserver | undefined
+  let disposed = false
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    renderer.setAnimationLoop(null)
+    observer?.disconnect()
+    geometries.forEach(geometry => geometry.dispose())
+    materials.forEach(material => material.dispose())
+    renderer.dispose()
+    renderer.domElement.remove()
+  }
+  try {
+    await renderer.init()
+    renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
+    renderer.shadowMap.enabled = true
+    renderer.info.autoReset = false
+    renderer.toneMapping = THREE.ACESFilmicToneMapping
+    const backend: Backend = (renderer.backend as unknown as { isWebGPUBackend?: boolean }).isWebGPUBackend ? 'webgpu' : 'webgl2'
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(0xc2d7e5)
+    const camera = new THREE.PerspectiveCamera(36, 1, 0.1, 500)
+    camera.position.set(-80, 85, 105)
+    camera.lookAt(0, 0, 0)
+    const daylight = new THREE.HemisphereLight(0xe8f4ff, 0x6e675a, 2)
+    scene.add(daylight)
+    const sun = new THREE.DirectionalLight(0xfff0d4, 3)
+    sun.position.set(-45, 75, 30)
+    sun.castShadow = true
+    sun.shadow.mapSize.set(1024, 1024)
+    sun.shadow.camera.left = sun.shadow.camera.bottom = -65
+    sun.shadow.camera.right = sun.shadow.camera.top = 65
+    sun.shadow.camera.far = 200
+    sun.shadow.bias = -0.0002
+    scene.add(sun)
+    const box = new THREE.BoxGeometry(1, 1, 1)
+    geometries.push(box)
+    const stone = new THREE.MeshStandardNodeMaterial({ color: 0xc9c3af, roughness: 0.85 })
+    const material = new THREE.MeshStandardNodeMaterial({ roughness: 0.35, metalness: 0.15 })
+    materials.push(stone, material)
+    const plinth = new THREE.Mesh(box, stone)
+    plinth.scale.set(CITY.buf.span + 8, 2, CITY.buf.span + 8)
+    plinth.position.y = CITY.buf.baseY - 1
+    plinth.receiveShadow = true
+    scene.add(plinth)
+    /* A fresh model's warm state is frozen so backend comparisons cannot drift
+     * with rendering speed. No alternate simulation or live performance claim. */
+    const buffers = createSim(createBus()).state.buffers
+    const columns = new THREE.InstancedMesh(box, material, buffers.sampleFrames)
+    const transform = new THREE.Object3D()
+    const color = new THREE.Color()
+    for (let i = 0; i < buffers.sampleFrames; i++) {
+      const [x, y, z] = bufferTilePos(i)
+      const { height, color: tint } = frameAppearance(!!buffers.valid[i], !!buffers.pinned[i], !!buffers.dirty[i], buffers.usage[i], CITY.buf.maxRise)
+      transform.position.set(x, y + height / 2, z)
+      transform.scale.set(CITY.buf.tile, height, CITY.buf.tile)
+      transform.updateMatrix()
+      columns.setMatrixAt(i, transform.matrix)
+      color.setHex(tint)
+      columns.setColorAt(i, color)
+    }
+    columns.castShadow = columns.receiveShadow = true
+    scene.add(columns)
+    host.append(renderer.domElement)
+    const resize = () => {
+      const width = Math.max(1, host.clientWidth)
+      const height = Math.max(1, host.clientHeight)
+      renderer.setSize(width, height, false)
+      camera.aspect = width / height
+      camera.updateProjectionMatrix()
+    }
+    resize()
+    observer = new ResizeObserver(resize)
+    observer.observe(host)
+    renderer.info.reset()
+    await renderer.renderAsync(scene, camera)
+    const firstFrameMs = performance.now() - started
+    let previous = performance.now()
+    let elapsed = 0
+    let frames = 0
+    let maximum = 0
+    let reports = 0
+    renderer.setAnimationLoop(() => {
+      if (disposed || document.hidden) { previous = performance.now(); return }
+      const now = performance.now()
+      const interval = now - previous
+      previous = now
+      elapsed += interval
+      frames++
+      maximum = Math.max(maximum, interval)
+      renderer.info.reset()
+      try { renderer.render(scene, camera) } catch {
+        report.textContent = 'Rendering stopped after a device or context failure. Return to the complete city or reload to retry.'
+        dispose()
+        return
+      }
+      if (elapsed >= 1000) {
+        reports++
+        report.textContent = `Backend: ${backend}\nWebGPU API exposed: ${'gpu' in navigator}\nFirst frame including model initialization: ${firstFrameMs.toFixed(1)} ms\nPresentation interval mean / maximum: ${(elapsed / frames).toFixed(1)} / ${maximum.toFixed(1)} ms (${frames} frames; window ${reports})\nWhole-frame draw calls / triangles: ${renderer.info.render.drawCalls} / ${renderer.info.render.triangles}\nRenderer-estimated memory: ${(renderer.info.memory.total / 1048576).toFixed(2)} MiB\nCanvas: ${renderer.domElement.width} × ${renderer.domElement.height}\nFrozen representative frames: ${buffers.sampleFrames}; model seed: 0xc0ffee\nHardware: not identified. Do not compare software rendering with a named hardware target.`
+        elapsed = frames = maximum = 0
+      }
+    })
+    window.addEventListener('pagehide', dispose, { once: true })
+    return backend
+  } catch (error) {
+    dispose()
+    throw error
+  }
+}

--- a/src/experimental/webgpu/sample.test.ts
+++ b/src/experimental/webgpu/sample.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'vitest'
+import { frameAppearance } from './sample'
+import { DAY_PALETTE } from '../../core/themes'
+
+it('preserves semantic precedence without conflating dirtiness and usage', () => {
+  expect(frameAppearance(false, true, true, 5, 5.2)).toEqual({ color: DAY_PALETTE.bufFree, height: 0.15 })
+  expect(frameAppearance(true, true, true, 0, 5.2)).toEqual({ color: DAY_PALETTE.bufPinned, height: 0.35 })
+  expect(frameAppearance(true, false, true, 5, 5.2)).toEqual({ color: DAY_PALETTE.bufDirty, height: 5.55 })
+  expect(frameAppearance(true, false, false, 0, 5.2)).toEqual({ color: DAY_PALETTE.bufClean, height: 0.35 })
+})

--- a/src/experimental/webgpu/sample.ts
+++ b/src/experimental/webgpu/sample.ts
@@ -1,0 +1,8 @@
+import { DAY_PALETTE } from '../../core/themes'
+
+export function frameAppearance(valid: boolean, pinned: boolean, dirty: boolean, usage: number, rise: number) {
+  return {
+    color: !valid ? DAY_PALETTE.bufFree : pinned ? DAY_PALETTE.bufPinned : dirty ? DAY_PALETTE.bufDirty : DAY_PALETTE.bufClean,
+    height: valid ? 0.35 + (usage / 5) * rise : 0.15,
+  }
+}

--- a/src/experimental/webgpu/session.test.ts
+++ b/src/experimental/webgpu/session.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createLabSession } from './session'
+
+describe('explicit renderer experiment boundary', () => {
+  it('does not import or probe a renderer before user action', () => {
+    const load = vi.fn()
+    createLabSession(load)
+    expect(load).not.toHaveBeenCalled()
+  })
+  it('starts once even when the start button is clicked twice', async () => {
+    const load = vi.fn(async () => 'webgl2' as const)
+    const session = createLabSession(load)
+    await Promise.all([session.start(), session.start()])
+    expect(load).toHaveBeenCalledTimes(1)
+    expect(session.state()).toEqual({ status: 'ready', backend: 'webgl2' })
+  })
+  it('reports failure without redirecting or retry loops', async () => {
+    const session = createLabSession(async () => { throw new Error('device denied') })
+    await session.start()
+    expect(session.state()).toEqual({ status: 'unavailable' })
+    await session.start()
+    expect(session.state()).toEqual({ status: 'unavailable' })
+  })
+})

--- a/src/experimental/webgpu/session.ts
+++ b/src/experimental/webgpu/session.ts
@@ -1,0 +1,20 @@
+export type Backend = 'webgpu' | 'webgl2'
+export type LabState = { status: 'idle' | 'loading' | 'unavailable' }
+  | { status: 'ready'; backend: Backend }
+
+export function createLabSession(load: () => Promise<Backend>) {
+  let current: LabState = { status: 'idle' }
+  let pending: Promise<void> | undefined
+  return {
+    state: (): LabState => current,
+    start(): Promise<void> {
+      if (pending) return pending
+      current = { status: 'loading' }
+      pending = Promise.resolve().then(load).then(
+        backend => { current = { status: 'ready', backend } },
+        () => { current = { status: 'unavailable' } },
+      )
+      return pending
+    },
+  }
+}

--- a/src/experimental/webgpu/style.css
+++ b/src/experimental/webgpu/style.css
@@ -1,0 +1,11 @@
+:root { color-scheme: light; font: 16px/1.5 system-ui, sans-serif; color: #162a3d; background: #edf2f6; }
+body { margin: 0; }
+main { max-width: 1100px; margin: auto; padding: 24px; }
+h1 { margin-bottom: 8px; }
+a { color: #17558c; }
+button, select { font: inherit; padding: 10px; }
+.controls { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; }
+#viewport { width: 100%; height: min(52vw, 520px); min-height: 280px; background: #c2d7e5; border-radius: 8px; overflow: hidden; }
+canvas { display: block; width: 100%; height: 100%; }
+pre { white-space: pre-wrap; overflow-wrap: anywhere; background: #fff; padding: 16px; }
+@media (max-width: 500px) { main { padding: 16px; } h1 { font-size: 26px; } }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,13 @@ if (
   input.machine = entry('./machine/index.html')
 }
 
+if (
+  process.env.PGSIMCITY_ENTRIES !== 'city' &&
+  allExist('./experimental/webgpu/index.html', './src/experimental/webgpu/main.ts', './src/experimental/webgpu/prototype.ts', './src/experimental/webgpu/session.ts', './src/experimental/webgpu/sample.ts', './src/experimental/webgpu/style.css')
+) {
+  input.webgpuLab = entry('./experimental/webgpu/index.html')
+}
+
 export default defineConfig({
   base: './',
   plugins: [{


### PR DESCRIPTION
## Summary
An explicit-start experiment at /experimental/webgpu/ uses a frozen simulation buffer sample, shared geography and semantic colors, node materials, instancing, shadows and MSAA. It exposes backend selection, WebGL2 fallback and local rendering counters.

Part of #17 / #10; keep #17 open for renderer adoption evaluation.

## Verification and scope
Four targeted tests, typecheck and build passed. No default city renderer switch or runtime dependency was added.

**Draft:** browser fallback/opt-in verification and full candidate tests remain. This is a representative lab, not full-city parity. SSGI, temporal AA, complete effects parity and named-hardware performance are explicitly unresolved. No performance multiplier is claimed.