### PR TITLE
fix: verify the PostgreSQL 18.6 reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ are all still moving. Expect breaking changes between minor versions.
 
 ### Fixed
 
+- Advance the reviewed PostgreSQL reference from 18.4 to 18.6 after checking
+  the release notes and rerunning all 223 oracle observations: 219 matches,
+  four existing teaching-scale divergences, no unexpected results. The version
+  gate still rejects unreviewed newer releases. Logical-decoding guidance now
+  includes the trusted output-plugin allowlist; PGlite remains separately
+  labeled as PostgreSQL 18.3. See [the reference review](POSTGRESQL-REFERENCE-REVIEW.md)
+  for evidence and coverage limits.
 - The CDP profile guard that keeps two concurrent screenshot runs from deleting
   each other's live Chrome profile only worked on Linux. `profileIsInUse()` read
   `/proc`, which macOS does not have, so the read threw and the guard reported

--- a/POSTGRESQL-REFERENCE-REVIEW.md
+++ b/POSTGRESQL-REFERENCE-REVIEW.md
@@ -1,0 +1,58 @@
+# PostgreSQL reference review
+
+The city targets the PostgreSQL 18 major line. Its reviewed reference is 18.6;
+the separate opt-in PGlite engine remains PostgreSQL 18.3 (PGlite 0.5.4).
+Updating the city reference does not update that engine or make the model an
+implementation of every PostgreSQL feature.
+
+## Verification boundary
+
+On 2026-09-04, the unchanged oracle ran against PostgreSQL
+`18.6 (Debian 18.6-1.pgdg13+2)`, using a local image based on the official
+`postgres:18.6` image with Node 22 added. The PostgreSQL image digest was
+`sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280`.
+The repository was mounted read-only; the harness created and removed its own
+throwaway clusters. No existing database was reused.
+
+Before advancing the reference, 223 observations produced 218 matches, four
+registered teaching-scale divergences, and one unexpected result: the reviewed
+reference still named 18.4. The run took 102.85 seconds on this machine.
+The version gate remains strict: a server newer than the reviewed reference
+still fails. The four model exceptions are unchanged.
+
+After advancing the reference, the same command produced 223 observations:
+219 matches, the same four registered divergences, and zero unexpected results
+in 111.44 seconds. No oracle comparisons or exception rules were relaxed.
+
+The oracle covers registered defaults, diagnostic SQL, WAL, locking, memory,
+backup/recovery, vacuum/MVCC, and the Machine's owned query examples. Its
+coverage and omissions are listed in [ORACLE-AUDIT.md](ORACLE-AUDIT.md).
+Passing these observations is not a claim that all PostgreSQL bugs or all city
+content are covered by automated tests.
+
+## Release-note review
+
+The [18.6 release notes](https://www.postgresql.org/docs/release/18.6/) cover
+changes from 18.4; 18.5 was never released. The following areas intersect the
+city's explanations:
+
+- Logical decoding now restricts output plugins through
+  `output_plugin_libraries`. The decoder documentation now qualifies third-party
+  plugins such as `wal2json` with installation and administrator approval;
+  [the parameter's documentation](https://www.postgresql.org/docs/18/runtime-config-replication.html#GUC-OUTPUT-PLUGIN-LIBRARIES)
+  is linked beside the explanation. The city does not configure plugins.
+- Autovacuum scheduling and failsafe buffer use, local-buffer streaming, and
+  free-space-map maintenance received fixes. The oracle checks vacuum reclamation
+  and defaults, not the launcher's multi-database scheduling or failsafe ring
+  behavior. The city remains a scaled model, not a reproduction of those bugs.
+- Visibility-map WAL, incremental backup, timeline changes, standby startup,
+  slot lifecycle, and replication progress received fixes. Existing oracle
+  exercises continue to check their registered mechanisms; they do not inject
+  torn pages, every concurrency race, or the complete incremental-backup path.
+- Planner, datatype, security, extension, client, and statistics fixes do not
+  justify claiming those internals are executed by the city. PGlite remains a
+  separate measured evidence source with its own disclosed version.
+
+This review advances the reference only within those boundaries. Independent
+release review is still required; this author-produced record is evidence for
+that review, not its substitute.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and what remains irreducibly spatial.
 > [Machine](machine/) can run PGlite, a real in-memory PostgreSQL compiled to
 > WebAssembly.
 >
-> PGSimCity targets the PostgreSQL 18 major line. PostgreSQL 18.4 is the
+> PGSimCity targets the PostgreSQL 18 major line. PostgreSQL 18.6 is the
 > reviewed reference release against which its claims were verified; mechanism
 > claims follow the [`REL_18_STABLE` source](https://github.com/postgres/postgres/tree/REL_18_STABLE).
 > For example, PostgreSQL 18's bulk-read strategy starts at 256 KiB and grows

--- a/index.html
+++ b/index.html
@@ -146,9 +146,9 @@
             data-correction-path="true"
             data-version-qualification="city"
           >
-            <summary data-disclosure="city-postgresql-version">PostgreSQL 18.4 · city claims</summary>
+            <summary data-disclosure="city-postgresql-version">PostgreSQL 18.6 · city claims</summary>
             <span class="pg-version-qualification__full" data-version-qualification-full="true">
-              This city's model and explanations describe PostgreSQL 18.4.
+              This city's model and explanations describe PostgreSQL 18.6.
             </span>
           </details>
         </section>

--- a/machine/index.html
+++ b/machine/index.html
@@ -51,8 +51,8 @@
               class="machine-provenance"
               data-version-qualification="machine"
             >
-              <summary data-disclosure="machine-postgresql-version">PostgreSQL 18.4 model · PGlite 18.3 engine</summary>
-              <span data-version-qualification-full="true">Model and explanations: PostgreSQL 18.4 · PGlite engine: PostgreSQL 18.3 (PGlite 0.5.4), checked separately with SELECT version().</span>
+              <summary data-disclosure="machine-postgresql-version">PostgreSQL 18.6 model · PGlite 18.3 engine</summary>
+              <span data-version-qualification-full="true">Model and explanations: PostgreSQL 18.6 · PGlite engine: PostgreSQL 18.3 (PGlite 0.5.4), checked separately with SELECT version().</span>
             </details>
           </div>
           <div class="header-side">

--- a/machine/mobile-layout.browser.test.js
+++ b/machine/mobile-layout.browser.test.js
@@ -290,7 +290,7 @@ describe('machine room portrait layout', () => {
 
     const version = reports[1].versionQualification
     expect(version.collapsed.found).toBe(true)
-    expect(version.collapsed.markerText).toContain('PostgreSQL 18.4')
+    expect(version.collapsed.markerText).toContain('PostgreSQL 18.6')
     expect(version.collapsed.fullVisible).toBe(false)
     expect(version.collapsed.correctionVisible).toBe(false)
     expect(version.collapsed.markerHeight).toBeGreaterThanOrEqual(version.collapsed.tapSize)

--- a/observability/README.md
+++ b/observability/README.md
@@ -67,7 +67,7 @@ These are hard constraints in the code, not aspirations.
    `wait_event_type`/`wait_event` pair, every vacuum `phase` string, every
    `pg_stat_io` `object` and `context` value — was checked against
     the [PostgreSQL 18 manual](https://www.postgresql.org/docs/18/) and verified
-    against PostgreSQL 18.4. Where a
+    against PostgreSQL 18.6. Where a
    name changed between releases the change is recorded and shown. The
    capitalisation counts: PostgreSQL 17 began generating the wait event list
    from a table and normalised it on the way through, so the WAL flush wait is

--- a/src/core/claims.ts
+++ b/src/core/claims.ts
@@ -15,7 +15,7 @@ const KIB = 1024
 const MIB = KIB * KIB
 const MODEL_MILLISECOND_UNIT = 'model ms'
 const POSTGRESQL_MAJOR = 18
-const POSTGRESQL_REFERENCE_MINOR = 4
+const POSTGRESQL_REFERENCE_MINOR = 6
 const MODEL_CONNECTION_RESERVATIONS = {
   superuser: 3,
   reserved: 0,

--- a/src/observability/catalog.ts
+++ b/src/observability/catalog.ts
@@ -2,7 +2,7 @@
  * THE INSTRUMENT CATALOG
  *
  * Every name in this file targets the PostgreSQL 18 major line and was checked
- * against its manual; default-value claims use the reviewed 18.4 release. If a
+ * against its manual; default-value claims use the reviewed 18.6 release. If a
  * column, view, function or enum value appears here, it exists. Where a name
  * changed between releases the change is recorded in `version`, because a
  * reader on 15 who copies an 18 query and gets "column does not exist" has been

--- a/src/ui/docs-storage.ts
+++ b/src/ui/docs-storage.ts
@@ -1112,6 +1112,10 @@ export const DOCS_STORAGE: ComponentDoc[] = [
         body: 'It requires `wal_level = logical`, which is a restart, and which makes WAL bigger because extra information has to be logged for decoding to be possible at all. It also requires a **replica identity** on any table you UPDATE or DELETE: by default that is the primary key, and a table with no primary key will error out unless you set `REPLICA IDENTITY FULL` (which logs the entire old row into WAL — correct, and expensive). Finally, it needs a logical slot, with all the disk-filling risk that carries.',
       },
       {
+        heading: 'Trusted output plugins',
+        body: 'In PostgreSQL 18.6, `output_plugin_libraries` defaults to `pgoutput, test_decoding`. A third-party plugin such as `wal2json` must be installed and added to this allowlist by an administrator after a safety review. The city does not configure output plugins; this is a real-server requirement.',
+      },
+      {
         heading: 'The reorder buffer',
         body: 'WAL is written in the order changes happened, interleaved across concurrent transactions, and it contains work from transactions that later rolled back. Consumers want committed transactions, whole, in commit order. The **reorder buffer** is what bridges that: it spools each transaction’s changes in memory until it sees the commit record, then emits them as a unit and discards aborted ones. Transactions bigger than `logical_decoding_work_mem` spill to disk, which is why one enormous batch UPDATE can stall an otherwise healthy CDC pipeline. PostgreSQL 14 added streaming of in-progress transactions to soften that.',
       },
@@ -1148,7 +1152,10 @@ export const DOCS_STORAGE: ComponentDoc[] = [
       'src/backend/replication/slot.c',
     ],
     refs: {
-      docs: [manual('logicaldecoding.html', 'Chapter 47. Logical Decoding')],
+      docs: [
+        manual('logicaldecoding.html', 'Chapter 47. Logical Decoding'),
+        manual('runtime-config-replication.html#GUC-OUTPUT-PLUGIN-LIBRARIES', 'Trusted logical output plugins'),
+      ],
       source: [
         srcFile('src/backend/replication/logical/decode.c', 'LogicalDecodingProcessRecord'),
         srcFile('src/backend/replication/logical/reorderbuffer.c', 'ReorderBufferProcessTXN, ReorderBufferCommit'),

--- a/test/content-corrections.test.ts
+++ b/test/content-corrections.test.ts
@@ -24,6 +24,15 @@ const diagnosticCopy = [...ALL_STEPS, ...ALL_VERDICTS]
   .join('\n')
 
 describe('PostgreSQL 18 content corrections', () => {
+  it('qualifies third-party decoding plugins with the server allowlist', () => {
+    const decoder = DOCS_STORAGE.find((doc) => doc.id === 'logical.decoder')!
+    const copy = decoder.sections.map((section) => section.body).join('\n')
+    expect(copy).toContain('output_plugin_libraries')
+    expect(copy).toContain('pgoutput, test_decoding')
+    expect(copy).toMatch(/wal2json.*installed.*allowlist/)
+    expect(copy).toContain('does not configure output plugins')
+  })
+
   it('keeps every documentation surface consistent with the replication link capacity', () => {
     const contradictions = DOCS.flatMap((entry) => {
       const copy = [


### PR DESCRIPTION
## Summary
Advance the reviewed PostgreSQL model reference from 18.4 to 18.6 after verifying the registered claims against an actual PostgreSQL 18.6 server. Keep the separately executed PGlite engine labeled 18.3. Qualify the 18.6 logical-decoding plugin allowlist requirement where plugin advice appears.

Closes #8. Part of #10 / Sprint 1.

## Evidence
- RED: actual PostgreSQL 18.6 produced 223 observations: 218 matches, four registered model divergences, one unexpected reference-version mismatch.
- GREEN: 223 observations: 219 matches, the same four registered divergences, zero unexpected results.
- No oracle comparison rules were relaxed.
- 1,011 non-browser tests, 81 focused checks, typecheck and build passed.
- POSTGRESQL-REFERENCE-REVIEW.md records the official Docker image digest, reviewed release notes and coverage limits. This was an official PostgreSQL image plus Node, not a source-compiled server.
- PostgreSQL 18.5 was never released; the reviewed transition is 18.4 to 18.6.

## Remaining gates
QA is checking visible version/plugin qualifications. Exact-head CI and independent PostgreSQL-fidelity review are required before merge. Passing the registered oracle is not a claim that the city models every PostgreSQL implementation detail or every 18.6 edge-case fix.