### PR TITLE
feat: clarify daylight and local haze

### DIFF
--- a/src/core/themes.test.ts
+++ b/src/core/themes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { heightFogAmount } from '../engine/color-grade'
 import {
   ATMOSPHERE,
   CLOCK_SUNRISE_MINUTES,
@@ -274,6 +275,17 @@ describe('daySurface — per-district stone', () => {
 })
 
 describe('the day sun', () => {
+  it('preserves local material contrast beneath the distance haze', () => {
+    const air = ATMOSPHERE.day
+    const near = heightFogAmount(550, 285, 0, air.heightFogDensity, air.heightFogFalloff)
+    const far = heightFogAmount(1050, 285, 0, air.heightFogDensity, air.heightFogFalloff)
+    // This is the additional ground-layer haze, on top of scene distance fog.
+    // Capping at 20% across the whole overview erased local material contrast.
+    expect(near).toBeLessThan(0.1)
+    expect(near).toBeGreaterThan(0.03)
+    expect(far).toBeGreaterThan(near * 1.5)
+  })
+
   it('lights roof planes while retaining legible cast shadows', () => {
     const { keyPos, keyTarget } = ATMOSPHERE.day
     const dx = keyPos[0] - keyTarget[0]

--- a/src/core/themes.test.ts
+++ b/src/core/themes.test.ts
@@ -274,7 +274,7 @@ describe('daySurface — per-district stone', () => {
 })
 
 describe('the day sun', () => {
-  it('rakes across the city low enough to cast shadows several storeys long', () => {
+  it('lights roof planes while retaining legible cast shadows', () => {
     const { keyPos, keyTarget } = ATMOSPHERE.day
     const dx = keyPos[0] - keyTarget[0]
     const dy = keyPos[1] - keyTarget[1]
@@ -286,9 +286,13 @@ describe('the day sun', () => {
     const elevation = Math.asin(ny) * (180 / Math.PI)
     const shadowRunPerMetre = Math.hypot(nx, nz) / ny
 
-    expect(elevation).toBeGreaterThanOrEqual(7)
-    expect(elevation).toBeLessThanOrEqual(10)
-    expect(shadowRunPerMetre).toBeGreaterThan(5.5)
+    // A near-horizon key left roofs grey and stretched tower shadows across
+    // several unrelated mechanisms. Keep shadows within a few storeys.
+    expect(elevation).toBeGreaterThanOrEqual(24)
+    expect(elevation).toBeLessThanOrEqual(32)
+    expect(shadowRunPerMetre).toBeGreaterThan(1.5)
+    expect(shadowRunPerMetre).toBeLessThan(2.3)
+    expect(ny * ATMOSPHERE.day.keyIntensity).toBeGreaterThan(1)
     // The north-west key throws the backend row across the plaza to the south-east.
     expect(nx).toBeLessThan(-0.5)
     expect(nz).toBeLessThan(-0.65)

--- a/src/core/themes.ts
+++ b/src/core/themes.ts
@@ -329,15 +329,13 @@ export const ATMOSPHERE: Record<CuratedThemeMode, Atmosphere> = {
     hemiIntensity: 0.82,
     keyColor: 0xffd6a3,
     keyIntensity: 2.25,
-    /*
-     * North-west at 8.4°. A one-metre object casts 6.81 m across the ground;
-     * the backend row therefore stripes the plaza to the south-east, and the
-     * establishing camera sees building silhouettes against the bright side.
-     */
-    keyPos: [-520, 120, -650],
+    /* A north-west afternoon key lights roofs and facades together. At 27° a
+     * tower's shadow stays within two heights, grounding its own machinery
+     * instead of striping several unrelated districts. */
+    keyPos: [-520, 420, -650],
     keyTarget: [0, 0, -20],
-    sunDirection: [-520, 120, -630],
-    sunElevationDeg: 8.4,
+    sunDirection: [-520, 420, -630],
+    sunElevationDeg: 27.2,
     shadowBias: -0.0004,
     shadowNormalBias: 0.2,
     shadowIntensity: 0.84,

--- a/src/core/themes.ts
+++ b/src/core/themes.ts
@@ -320,7 +320,9 @@ export const ATMOSPHERE: Record<CuratedThemeMode, Atmosphere> = {
      */
     fogNearScale: 1.2,
     fogFarScale: 1.65,
-    heightFogDensity: 0.0014,
+    // This layers over distance fog: at home framing it must not flatten
+    // every facade into the same haze colour before the far districts recede.
+    heightFogDensity: 0.00025,
     heightFogFalloff: 0.018,
     fogColor: DAY_PALETTE.fog,
     plateFogScale: 0.84,


### PR DESCRIPTION
## Summary
Raise the fixed day-mode sun and reduce additional near-city height haze while retaining the semantic palette and far-distance fog.

Part of #12 / #10. Commits5520d81 and3de0340, stacked on materialsPR#23.

## Evidence and remaining gates
42 focused tests, typecheck and build passed. Authors and QA inspected combined trial captures and judged a modest improvement, not the premium endpoint. The final candidate needs exact-tier/viewport evidence and complete CI. Future structural-albedo work is a separate branch, not included here.

Draft until candidate visual acceptance and exact-head CI are complete. Substantive REV and cross-model release review remain required.