### PR TITLE
feat: deepen backend tower architecture

### DIFF
--- a/src/world/backends-architecture.test.ts
+++ b/src/world/backends-architecture.test.ts
@@ -1,0 +1,89 @@
+import * as THREE from 'three'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createBus } from '../core/bus'
+import { createTheme } from '../core/theme'
+import { N_BACKEND_SLOTS } from '../core/types'
+import { createSim } from '../sim/model'
+import { installTestDom } from '../../test/dom'
+import { createBackends } from './backends'
+import { CITY, backendX } from './layout'
+
+const disposers: (() => void)[] = []
+afterEach(() => { while (disposers.length) disposers.pop()!() })
+
+function fixture() {
+  installTestDom({ canvas2d: true })
+  const bus = createBus(), sim = createSim(bus), theme = createTheme()
+  const module = createBackends({
+    scene: new THREE.Scene(), camera: new THREE.PerspectiveCamera(), bus,
+    sim: sim.state, theme,
+    quality: { level: 'high', pixelRatio: 1, bloom: true, shadows: true, maxParticles: 1, maxLabels: 1, antialias: true },
+    register: () => {}, flow: () => {},
+  })
+  disposers.push(() => { module.dispose?.(); theme.dispose() })
+  const meshes: THREE.InstancedMesh[] = []
+  module.group.traverse((object) => {
+    if (object instanceof THREE.InstancedMesh) meshes.push(object)
+  })
+  const byMaterial = (name: string) => meshes.filter((mesh) => !Array.isArray(mesh.material) && mesh.material.name === name)
+  return { module, byMaterial }
+}
+
+describe('backend process architecture', () => {
+  it('recesses the central service spine while retaining the status facade on each side', () => {
+    const { byMaterial } = fixture()
+    const shaft = byMaterial('backends.shaft')[0]
+    const transform = new THREE.Matrix4()
+    shaft.getMatrixAt(0, transform)
+    const center = new THREE.Vector3().setFromMatrixPosition(transform)
+    const ray = new THREE.Raycaster()
+    function faceDepth(offset: number) {
+      ray.set(new THREE.Vector3(backendX(0) + offset, center.y, CITY.backend.z + 20), new THREE.Vector3(0, 0, -1))
+      return ray.intersectObject(shaft)[0].point.z
+    }
+    expect(faceDepth(0)).toBeLessThan(faceDepth(CITY.backend.w * 0.25) - 0.5)
+    expect(faceDepth(CITY.backend.w * 0.34)).toBeCloseTo(CITY.backend.z + CITY.backend.w / 2, 3)
+  })
+
+  it('keeps the supporting silhouette visible at city distance without extra material batches', () => {
+    const { module, byMaterial } = fixture()
+    module.setDetail?.(0)
+    const structure = byMaterial('backends.struct')[0]
+    const shaft = byMaterial('backends.shaft')[0]
+    expect(structure.visible).toBe(true)
+    const transform = new THREE.Matrix4()
+    const scale = new THREE.Vector3(), position = new THREE.Vector3()
+    let buttresses = 0
+    for (let i = 0; i < structure.count; i++) {
+      structure.getMatrixAt(i, transform)
+      scale.setFromMatrixScale(transform)
+      position.setFromMatrixPosition(transform)
+      if (scale.y > 4 && scale.x < 2) buttresses++
+    }
+    expect(buttresses).toBe(N_BACKEND_SLOTS * 4)
+    expect(byMaterial('backends.struct')).toHaveLength(3) // structure, existing memory ticks and temporary files
+    expect(byMaterial('backends.shaft')).toHaveLength(1)
+    expect(shaft.count).toBe(N_BACKEND_SLOTS)
+    expect(structure.count).toBeLessThanOrEqual(N_BACKEND_SLOTS * 8)
+  })
+
+  it('keeps every structural mass in its plinth envelope and leaves private-memory sightlines open', () => {
+    const { byMaterial } = fixture()
+    const structure = byMaterial('backends.struct')[0]
+    const transform = new THREE.Matrix4()
+    const scale = new THREE.Vector3(), position = new THREE.Vector3()
+    for (let i = 0; i < structure.count; i++) {
+      structure.getMatrixAt(i, transform)
+      scale.setFromMatrixScale(transform)
+      position.setFromMatrixPosition(transform)
+      const slot = Math.round((position.x + CITY.backend.span / 2) / (CITY.backend.span / (N_BACKEND_SLOTS - 1)))
+      const offset = position.x - backendX(slot)
+      expect(Math.abs(offset) + scale.x / 2).toBeLessThanOrEqual(CITY.backend.w / 2 + 1.61)
+      expect(Math.abs(position.z - CITY.backend.z) + scale.z / 2).toBeLessThanOrEqual(CITY.backend.w / 2 + 1.61)
+      if (scale.y > 4) {
+        // The reservoir occupies the positive-z face, x = 3.4 ± 1.35 m.
+        expect(offset + scale.x / 2 < 2 || offset - scale.x / 2 > 4.75 || position.z + scale.z / 2 < CITY.backend.z + 5).toBe(true)
+      }
+    }
+  })
+})

--- a/src/world/backends.ts
+++ b/src/world/backends.ts
@@ -142,6 +142,8 @@ varying float vScroll;
 varying float vWipe;
 varying float vHeight;
 void main() {
+  // The middle bay is a recessed service spine, not a floating window surface.
+  if ( abs( vPos.x ) < 0.101 && abs( vPos.z ) > 0.49 ) discard;
   // metres up the shaft, so the floor pitch is constant across tower heights
   float y = ( vPos.y + 0.5 ) * vHeight;
   // whichever horizontal axis varies on this face gives us window columns
@@ -244,7 +246,8 @@ export const createBackends: WorldFactory = (ctx): WorldModule => {
   }
 
   /* --- structure (matte, never glows) ----------------------------------- */
-  const structMesh = new THREE.InstancedMesh(unitBox, matStruct, N * 2)
+  const STRUCT_PARTS = 8
+  const structMesh = new THREE.InstancedMesh(unitBox, matStruct, N * STRUCT_PARTS)
   structMesh.frustumCulled = false
   const trimMesh = new THREE.InstancedMesh(unitBox, matTrim, N * 3)
   trimMesh.frustumCulled = false
@@ -256,8 +259,20 @@ export const createBackends: WorldFactory = (ctx): WorldModule => {
     const top = PLINTH_H + SH[i]
     const plinth: BoxSpec = [x, PLINTH_H / 2, BZ, BW + 3.2, PLINTH_H, BW + 3.2]
     const collar: BoxSpec = [x, top + COLLAR_H / 2, BZ, BW + 1.3, COLLAR_H, BW + 1.3]
-    setBox(structMesh, i * 2, plinth)
-    setBox(structMesh, i * 2 + 1, collar)
+    const first = i * STRUCT_PARTS
+    setBox(structMesh, first, plinth)
+    setBox(structMesh, first + 1, collar)
+    // A repeated supporting frame identifies the process family without hiding its state skin.
+    for (let corner = 0; corner < 4; corner++) {
+      const side = corner < 2 ? -1 : 1
+      const face = corner % 2 === 0 ? -1 : 1
+      setBox(structMesh, first + 2 + corner, [
+        x + side * (BW / 2 + 0.45), PLINTH_H + (SH[i] - 1.1) / 2,
+        BZ + face * (BW / 2 - 0.4), 0.85, SH[i] - 1.1, 1,
+      ])
+    }
+    setBox(structMesh, first + 6, [x - BW / 2 - 0.2, top - 0.55, BZ, 1.7, 1.1, BW])
+    setBox(structMesh, first + 7, [x + BW / 2 + 0.2, top - 0.55, BZ, 1.7, 1.1, BW])
     pushBoxEdges(edgeVerts, plinth)
     pushBoxEdges(edgeVerts, [x, SY[i], BZ, BW, SH[i], BW])
     pushBoxEdges(edgeVerts, collar)
@@ -284,7 +299,19 @@ export const createBackends: WorldFactory = (ctx): WorldModule => {
   group.add(structMesh, trimMesh, ventMesh)
 
   /* --- shafts (one instanced mesh, per-instance colour) ------------------ */
-  const shaftMesh = new THREE.InstancedMesh(unitBox, matShaft, N)
+  // One extruded profile supplies real self-shading recesses for every process.
+  const shaftProfile = new THREE.Shape()
+  shaftProfile.moveTo(-0.5, -0.5)
+  for (const [x, z] of [
+    [-0.1, -0.5], [-0.1, -0.42], [0.1, -0.42], [0.1, -0.5],
+    [0.5, -0.5], [0.5, 0.5], [0.1, 0.5], [0.1, 0.42],
+    [-0.1, 0.42], [-0.1, 0.5], [-0.5, 0.5],
+  ]) shaftProfile.lineTo(x, z)
+  shaftProfile.closePath()
+  const shaftGeo = own(new THREE.ExtrudeGeometry(shaftProfile, { depth: 1, bevelEnabled: false, steps: 1 }))
+  shaftGeo.rotateX(Math.PI / 2)
+  shaftGeo.translate(0, 0.5, 0)
+  const shaftMesh = new THREE.InstancedMesh(shaftGeo, matShaft, N)
   shaftMesh.frustumCulled = false
   for (let i = 0; i < N; i++) setBox(shaftMesh, i, [XS[i], SY[i], BZ, BW, SH[i], BW])
   shaftMesh.instanceMatrix.needsUpdate = true


### PR DESCRIPTION
## Summary
Recessed service faces and stepped shoulders make backend towers read as a distinctive process district. Preserve one process per tower, private-memory sightlines, status surfaces, bounds and repeated family resemblance.

Part of #16 / #10. Feature commit e750ec4, stacked on vacuum geometryPR#27.

## Evidence and remaining gates
Focused geometry tests, typecheck and build passed. The pass adds zero material or draw-call batches; reported geometry delta is4,224 triangles medium/high and1,664 low. An actual row-focus image was inspected, but it used older source-branch HUD/labels.

Draft: integrated visual acceptance and regenerated/quality-stable baked light are blocking. Do not silently ship lost baked lighting after changed geometry signatures. No full-city premium acceptance is claimed.