### PR TITLE
feat: preserve incidents across diagnosis

### DIFF
--- a/machine/mobile-layout.browser.test.js
+++ b/machine/mobile-layout.browser.test.js
@@ -241,6 +241,7 @@ describe('machine room portrait layout', () => {
         if (!window.PGSIMCITY) throw new Error('city API did not become ready')
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
         window.PGSIMCITY.bus.emit('select', { id: 'recovery.ground' })
       })()`,
     }, {
@@ -254,6 +255,7 @@ describe('machine room portrait layout', () => {
         if (!window.PGSIMCITY) throw new Error('city API did not become ready')
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
         window.PGSIMCITY.bus.emit('select', { id: 'client.pooler' })
       })()`,
     }])

--- a/src/core/incident-handoff.test.ts
+++ b/src/core/incident-handoff.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { createBus } from './bus'
+import { createSim } from '../sim/model'
+import { createIncidentReplay } from '../sim/replay'
+import { readIncidentHandoff, writeIncidentHandoff, HANDOFF_KEY, HANDOFF_TTL } from './incident-handoff'
+
+function storage() {
+  const data = new Map<string, string>()
+  return { getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => { data.set(key, value) },
+    removeItem: (key: string) => { data.delete(key) } }
+}
+function model(seed = 42) {
+  const bus = createBus()
+  const sim = createSim(bus, { seed })
+  return { sim, replay: createIncidentReplay(sim, bus) }
+}
+describe('tab-local incident navigation', () => {
+  it('round trips the complete model, clock, actions and selected object', async () => {
+    const source = model()
+    source.sim.runScenario('vacuum-blockade')
+    for (let i = 0; i < 90; i++) source.sim.update(1 / 30)
+    const store = storage()
+    writeIncidentHandoff(store, source.replay, 'diagnose', { selected: 'storage.table.sessions' }, 100)
+    const read = readIncidentHandoff(store, '#incident', 'diagnose', 101)
+    expect(read.kind).toBe('ready')
+    if (read.kind !== 'ready') throw new Error('Missing incident')
+    const target = model(read.value.record.seed)
+    await target.replay.loadRecord(read.value.record)
+    expect(target.sim.state).toEqual(source.sim.state)
+    expect(read.value.context.selected).toBe('storage.table.sessions')
+    target.sim.setKnob('tps', 100)
+    writeIncidentHandoff(store, target.replay, 'city', read.value.context, 102)
+    const returned = readIncidentHandoff(store, '#incident', 'city', 103)
+    if (returned.kind !== 'ready') throw new Error('Missing return')
+    await source.replay.loadRecord(returned.value.record)
+    expect(source.sim.state).toEqual(target.sim.state)
+  })
+  it('does not restore or read storage without an explicit marker', () => {
+    expect(readIncidentHandoff(() => { throw new Error('unavailable') }, '', 'city', 100)).toEqual({ kind: 'none' })
+  })
+  it('rejects stale, missing and wrong-destination records visibly', () => {
+    const store = storage()
+    const { replay } = model()
+    expect(readIncidentHandoff(store, '#incident', 'city', 100).kind).toBe('error')
+    writeIncidentHandoff(store, replay, 'city', {}, 100)
+    expect(readIncidentHandoff(store, '#incident', 'diagnose', 101).kind).toBe('error')
+    expect(readIncidentHandoff(store, '#incident', 'city', 101 + HANDOFF_TTL).kind).toBe('error')
+  })
+  it.each(['null', '{', 'x'.repeat(110_000), '{"__proto__":{}}'])('rejects malicious stored data', (raw) => {
+    const store = storage()
+    store.setItem(HANDOFF_KEY, raw)
+    expect(readIncidentHandoff(store, '#incident', 'city', 100).kind).toBe('error')
+  })
+  it('reports unavailable storage and unsupported model actions', () => {
+    expect(readIncidentHandoff(() => { throw new Error('disabled') }, '#incident', 'city', 100).kind).toBe('error')
+    const { sim, replay } = model()
+    sim.setTraceMode('step')
+    expect(() => writeIncidentHandoff(storage(), replay, 'city', {}, 100)).toThrow(/Unsupported/)
+    expect(() => writeIncidentHandoff(() => { throw new Error('denied') }, model().replay, 'city', {}, 100)).toThrow(/storage is unavailable/)
+  })
+  it('consumes a transfer so refresh cannot silently rewind to stale state', () => {
+    const store = storage()
+    writeIncidentHandoff(store, model().replay, 'city', {}, 100)
+    expect(readIncidentHandoff(store, '#incident', 'city', 101).kind).toBe('ready')
+    expect(readIncidentHandoff(store, '#incident', 'city', 102).kind).toBe('error')
+  })
+  it('rejects version mismatch, future creation and unbounded context', () => {
+    const store = storage()
+    writeIncidentHandoff(store, model().replay, 'city', {}, 100)
+    const raw = JSON.parse(store.getItem(HANDOFF_KEY)!)
+    raw.record.modelVersion = 'different'
+    store.setItem(HANDOFF_KEY, JSON.stringify(raw))
+    expect(readIncidentHandoff(store, '#incident', 'city', 101)).toMatchObject({ kind: 'error', message: 'Replay model-version mismatch' })
+    writeIncidentHandoff(store, model().replay, 'city', {}, 100)
+    expect(readIncidentHandoff(store, '#incident', 'city', 99).kind).toBe('error')
+    expect(() => writeIncidentHandoff(store, model().replay, 'city', { selected: '<script>' }, 100)).toThrow(/selection/)
+  })
+  it('preserves diagnostic history and accepts the exact expiry boundary', () => {
+    const store = storage()
+    const context = { selected: 'storage.table.sessions', diagnosis: {
+      symptom: 'bloat', node: 'bloat.2', trail: ['bloat.1'],
+    } }
+    writeIncidentHandoff(store, model().replay, 'city', context, 100)
+    const result = readIncidentHandoff(store, '#incident', 'city', 100 + HANDOFF_TTL)
+    expect(result.kind === 'ready' && result.value.context).toEqual(context)
+    expect(() => writeIncidentHandoff(store, model().replay, 'city', {
+      diagnosis: { symptom: 'bloat', node: 'bloat.2', trail: Array(31).fill('bloat.1') },
+    }, 100)).toThrow(/history/)
+  })
+})

--- a/src/core/incident-handoff.ts
+++ b/src/core/incident-handoff.ts
@@ -81,6 +81,6 @@ export function readIncidentHandoff(
     storage(source).removeItem(HANDOFF_KEY)
     return { kind: 'ready', value }
   } catch (error) {
-    return { kind: 'error', message: error instanceof Error ? error.message : 'Incident storage is unavailable' }
+    return { kind: 'error', message: error instanceof Error ? error.message.slice(0, 300) : 'Incident storage is unavailable' }
   }
 }

--- a/src/core/incident-handoff.ts
+++ b/src/core/incident-handoff.ts
@@ -1,0 +1,86 @@
+import { decodeReplay, encodeReplay, REPLAY_MAX_BYTES } from '../sim/replay'
+import type { IncidentReplay, ReplayRecord } from '../sim/replay'
+
+export const HANDOFF_KEY = 'pgsimcity.incident-handoff.v1'
+export const HANDOFF_TTL = 30 * 60 * 1000
+const MAX_BYTES = REPLAY_MAX_BYTES + 4096
+type StoragePort = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+type StorageSource = StoragePort | (() => StoragePort)
+export type IncidentDestination = 'city' | 'diagnose'
+export interface IncidentContext {
+  selected?: string
+  diagnosis?: { symptom: string; node: string; trail: string[] } | { instrument: string }
+}
+export interface IncidentHandoff {
+  version: 1
+  destination: IncidentDestination
+  created: number
+  record: ReplayRecord
+  context: IncidentContext
+}
+export type IncidentHandoffResult = { kind: 'none' } | { kind: 'error'; message: string }
+  | { kind: 'ready'; value: IncidentHandoff }
+
+function storage(source: StorageSource): StoragePort {
+  return typeof source === 'function' ? source() : source
+}
+function object(value: unknown, keys: string[]): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+    || Object.keys(value).some((key) => !keys.includes(key))) throw new Error('Invalid incident navigation data')
+  return value as Record<string, unknown>
+}
+function id(value: unknown): string {
+  if (typeof value !== 'string' || !/^[a-zA-Z0-9_.:-]{1,100}$/.test(value)) throw new Error('Invalid incident selection')
+  return value
+}
+function context(value: unknown): IncidentContext {
+  const item = object(value, ['selected', 'diagnosis'])
+  const result: IncidentContext = {}
+  if (item.selected !== undefined) result.selected = id(item.selected)
+  if (item.diagnosis !== undefined) {
+    const entry = object(item.diagnosis, ['symptom', 'node', 'trail', 'instrument'])
+    if (entry.instrument !== undefined) {
+      if (Object.keys(entry).length !== 1) throw new Error('Invalid diagnostic navigation')
+      result.diagnosis = { instrument: id(entry.instrument) }
+    } else {
+      if (!Array.isArray(entry.trail) || entry.trail.length > 30) throw new Error('Invalid diagnostic history')
+      result.diagnosis = { symptom: id(entry.symptom), node: id(entry.node), trail: entry.trail.map(id) }
+    }
+  }
+  return result
+}
+
+/** Only a fixed marker enters navigation URLs; the bounded payload stays in this tab. */
+export function writeIncidentHandoff(
+  source: StorageSource, replay: IncidentReplay, destination: IncidentDestination,
+  selection: IncidentContext, now = Date.now(),
+): void {
+  const value: IncidentHandoff = { version: 1, destination, created: now,
+    record: decodeReplay(encodeReplay(replay.exportRecord())), context: context(selection) }
+  const text = JSON.stringify(value)
+  if (text.length > MAX_BYTES) throw new Error('Incident navigation size limit exceeded')
+  try { storage(source).setItem(HANDOFF_KEY, text) }
+  catch { throw new Error('Tab storage is unavailable; the incident has not been transferred') }
+}
+
+export function readIncidentHandoff(
+  source: StorageSource, hash: string, destination: IncidentDestination, now = Date.now(),
+): IncidentHandoffResult {
+  if (hash !== '#incident') return { kind: 'none' }
+  try {
+    const text = storage(source).getItem(HANDOFF_KEY)
+    if (!text) throw new Error('Incident navigation data is missing; return to the originating tab')
+    if (text.length > MAX_BYTES) throw new Error('Incident navigation size limit exceeded')
+    const item = object(JSON.parse(text), ['version', 'destination', 'created', 'record', 'context'])
+    if (item.version !== 1) throw new Error('Unsupported incident navigation version')
+    if (item.destination !== destination) throw new Error('This incident transfer belongs to another view')
+    if (typeof item.created !== 'number' || !Number.isFinite(item.created)
+      || item.created > now || now - item.created > HANDOFF_TTL) throw new Error('Incident transfer expired; send it again from the originating view')
+    const value: IncidentHandoff = { version: 1, destination, created: item.created,
+      record: decodeReplay(encodeReplay(item.record)), context: context(item.context) }
+    storage(source).removeItem(HANDOFF_KEY)
+    return { kind: 'ready', value }
+  } catch (error) {
+    return { kind: 'error', message: error instanceof Error ? error.message : 'Incident storage is unavailable' }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ import { CLAIM_VALUES } from './core/claims'
 import { createCorrectionPath, displayedClaim, protectCorrectionLink } from './core/corrections'
 import { Registry } from './core/registry'
 import { installCityComponentRoutes } from './core/city-route'
+import { readIncidentHandoff } from './core/incident-handoff'
+import { installCityIncidentNavigation, installIncidentCacheGuard, showIncidentError, STALE_INCIDENT_MESSAGE } from './ui/incident-navigation'
 import {
   atmosphere,
   createTheme,
@@ -128,6 +130,12 @@ async function boot(): Promise<void> {
   const canvasRoot = document.getElementById('canvas-root')
   const labelsRoot = document.getElementById('labels-root')
   if (!canvasRoot || !labelsRoot) throw new Error('DOM shell is missing')
+  const incoming = readIncidentHandoff(() => sessionStorage, window.location.hash, 'city')
+  if (incoming.kind === 'error') {
+    finishBoot(bootSurface)
+    showIncidentError(incoming.message)
+    return
+  }
 
   // --- WebGL2 gate -----------------------------------------------------------
   const probe = document.createElement('canvas')
@@ -154,9 +162,23 @@ async function boot(): Promise<void> {
   const rig = createCameraRig(camera, renderer.domElement, bus)
 
   await progress(BOOT_STEPS.simulation)
-  const sim = createSim(bus)
+  const sim = createSim(bus, incoming.kind === 'ready' ? { seed: incoming.value.record.seed } : {})
   const replay = createIncidentReplay(sim, bus)
-  if (reduceMotion()) sim.setKnob('paused', true)
+  if (incoming.kind === 'ready') {
+    try {
+      await replay.loadRecord(incoming.value.record)
+    } catch (error) {
+      replay.dispose()
+      rig.dispose()
+      gfx.dispose()
+      theme.dispose()
+      audio.dispose()
+      stopAnalytics()
+      finishBoot(bootSurface)
+      showIncidentError(error instanceof Error ? error.message : 'Incident restoration failed')
+      return
+    }
+  } else if (reduceMotion()) sim.setKnob('paused', true)
 
   // --- the context every district is built against ---------------------------
   const ctx: WorldContext = {
@@ -520,6 +542,19 @@ async function boot(): Promise<void> {
     location: window.location,
     target: window,
   })
+  const stopIncidentNavigation = installCityIncidentNavigation({
+    replay, bus, context: incoming.kind === 'ready' ? incoming.value.context : undefined,
+  })
+  const restoredSelection = incoming.kind === 'ready' ? incoming.value.context.selected : undefined
+  if (restoredSelection) {
+    if (registry.get(restoredSelection)) {
+      bus.emit('select', { id: restoredSelection })
+      bus.emit('focus', { id: restoredSelection, instant: true })
+    } else {
+      const warning = showIncidentError('The selected component is unavailable')
+      warning.textContent = 'Incident state restored. The selected component is unavailable; choose an object to inspect. No replacement incident was started.'
+    }
+  }
   frame()
 
   finishBoot(bootSurface)
@@ -539,6 +574,8 @@ async function boot(): Promise<void> {
     window.removeEventListener('keydown', resumePreferredAudio, true)
     offAudioToggle()
     stopCityComponentRoutes()
+    stopIncidentNavigation()
+    stopIncidentCacheGuard()
     stopAnalytics()
     analytics.dispose()
     timer.disconnect()
@@ -557,11 +594,14 @@ async function boot(): Promise<void> {
     gfx.dispose()
     theme.dispose()
   }
-  // pagehide also fires when the page goes into the back/forward cache, where it
-  // is expected to come back alive. Only tear down when it is a real unload.
+  const stopIncidentCacheGuard = installIncidentCacheGuard(() => {
+    dispose()
+    showIncidentError(STALE_INCIDENT_MESSAGE)
+  })
+  // A cached page is frozen here; the pageshow guard rejects its older incident.
   window.addEventListener('pagehide', (e: PageTransitionEvent) => {
     if (e.persisted) {
-      running = false // pause; pageshow restarts the loop
+      running = false
       return
     }
     dispose()

--- a/src/observability/main.ts
+++ b/src/observability/main.ts
@@ -21,6 +21,10 @@ import { createBus } from '../core/bus'
 import { CLAIM_VALUES } from '../core/claims'
 import { createCorrectionPath, displayedClaim } from '../core/corrections'
 import { createSim } from '../sim/model'
+import { createIncidentReplay } from '../sim/replay'
+import { readIncidentHandoff } from '../core/incident-handoff'
+import type { IncidentContext } from '../core/incident-handoff'
+import { incidentCitySelection, showIncidentError, transferIncident } from '../ui/incident-navigation'
 import { SCENARIOS } from '../sim/scenarios'
 import { DEFAULT_KNOBS } from '../core/types'
 import type { Knobs } from '../core/types'
@@ -54,8 +58,13 @@ const analytics = startAnalytics('observability')
 
 const bus = createBus()
 analytics.listen(bus)
-const sim = createSim(bus)
-if (reduceMotion()) sim.setKnob('paused', true)
+const incoming = readIncidentHandoff(() => sessionStorage, location.hash, 'diagnose')
+const sim = createSim(bus, incoming.kind === 'ready' ? { seed: incoming.value.record.seed } : {})
+const replay = createIncidentReplay(sim, bus)
+const linkedIncident = incoming.kind === 'ready'
+const incidentContext: IncidentContext = linkedIncident ? incoming.value.context : {}
+let navigationReady = false
+if (incoming.kind === 'none' && reduceMotion()) sim.setKnob('paused', true)
 const coll = createCollector(sim)
 
 /**
@@ -236,6 +245,29 @@ const skipLink = el('a', {
   },
 })
 root.replaceChildren(skipLink, top, mainBody)
+const incidentNotice = el('p', { class: 'rail__note', text: linkedIncident
+  ? 'Linked city incident: symptoms inspect this model without staging another workload. Diagnostic counters and rate windows start on arrival; the incident clock and model state continue. These are not PostgreSQL measurements. Query flow and Machine use separate, opt-in PGlite databases.'
+  : 'This is a separate diagnostic model. Query flow and Machine use separate, opt-in PGlite databases.' })
+
+function returnToCity(href = '../'): void {
+  if (!navigationReady) return
+  const context: IncidentContext = { ...incidentContext,
+    selected: incidentCitySelection(href, incidentContext.selected) }
+  if (screen.kind === 'console') context.diagnosis = {
+    symptom: screen.symptom.id, node: screen.nodeId, trail: screen.trail,
+  }
+  else if (screen.kind === 'instrument') context.diagnosis = { instrument: screen.id }
+  else delete context.diagnosis
+  transferIncident({ replay, destination: 'city', context, href })
+}
+root.addEventListener('click', (event) => {
+  const anchor = event.target instanceof Element ? event.target.closest('a') : null
+  if (!anchor || event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey
+    || anchor.target === '_blank') return
+  if (anchor !== brand && !anchor.classList.contains('city-exit') && !anchor.classList.contains('citylink')) return
+  event.preventDefault()
+  returnToCity(anchor.href)
+})
 
 /* ---------------------------------------------------------------------------
  * Rail
@@ -311,7 +343,9 @@ function buildRail(): void {
 
   railBody.replaceChildren(
     railHeading('Where does it hurt?'),
-    el('p', { class: 'rail__note', text: 'Pick a complaint. The model is put into a state that produces it, and you are walked to the column that proves it.' }),
+    el('p', { class: 'rail__note', text: linkedIncident
+      ? 'Pick a complaint to inspect the linked city incident. No replacement workload is staged.'
+      : 'Pick a complaint. The model is put into a state that produces it, and you are walked to the column that proves it.' }),
     symptomList,
     railHeading('Instruments', versionRail),
     el('p', { class: 'rail__note', text: 'Every view this model can serve, live. Change the version to see what you would be blind to.' }),
@@ -345,9 +379,11 @@ function openFlow(): void {
 }
 
 function openSymptom(s: Symptom): void {
-  stage(s.scenario, s.stageKnobs)
-  coll.reset()
-  warm(s.warmSeconds ?? 90)
+  if (!linkedIncident) {
+    stage(s.scenario, s.stageKnobs)
+    coll.reset()
+    warm(s.warmSeconds ?? 90)
+  }
   screen = { kind: 'console', symptom: s, nodeId: s.entry, trail: [] }
   analytics.track(ANALYTICS_EVENTS.panelOpened, {
     panel: 'observability',
@@ -373,7 +409,7 @@ function openInstrument(id: string): void {
 function goto(nodeId: string): void {
   if (screen.kind !== 'console') return
   const next = NODES.get(nodeId)
-  if (next && next.kind === 'step' && next.settle) settle(next.settle, 30)
+  if (!linkedIncident && next && next.kind === 'step' && next.settle) settle(next.settle, 30)
   screen = { ...screen, nodeId, trail: [...screen.trail, screen.nodeId] }
   render()
   focusPaneHeading()
@@ -1072,7 +1108,7 @@ function render(): void {
     claim: () => correctionClaim(content),
     context: correctionContext,
   })
-  pane.replaceChildren(...[banner, content, footer()].filter(Boolean).map((x) => x as HTMLElement))
+  pane.replaceChildren(...[incidentNotice, banner, content, footer()].filter(Boolean).map((x) => x as HTMLElement))
 }
 
 /* ---------------------------------------------------------------------------
@@ -1108,7 +1144,7 @@ function frame(now: number): void {
   requestAnimationFrame(frame)
 }
 
-installCityEscape()
+installCityEscape(() => returnToCity())
 
 window.addEventListener('keydown', (e) => {
   if (e.key !== ' ') return
@@ -1124,10 +1160,43 @@ window.addEventListener('keydown', (e) => {
  * server doing essentially nothing. Nobody diagnoses an idle database, and a
  * page about statistics whose first impression is a row of zeros has already
  * lost the argument. Start it under an ordinary OLTP load instead. */
-stage('steady-state')
-coll.reset()
-warm(60)
-
-buildRail()
-render()
-requestAnimationFrame(frame)
+async function boot(): Promise<void> {
+  if (incoming.kind === 'error') {
+    root!.replaceChildren()
+    showIncidentError(incoming.message, root!)
+    return
+  }
+  if (incoming.kind === 'ready') {
+    try {
+      await replay.loadRecord(incoming.value.record)
+      const diagnosis = incidentContext.diagnosis
+      if (diagnosis && 'instrument' in diagnosis) {
+        if (!BY_ID.has(diagnosis.instrument)) throw new Error('The diagnostic instrument is unavailable in this version')
+        screen = { kind: 'instrument', id: diagnosis.instrument }
+      } else if (diagnosis) {
+        const symptom = SYMPTOMS.find((item) => item.id === diagnosis.symptom)
+        if (!symptom || !NODES.has(diagnosis.node) || diagnosis.trail.some((id) => !NODES.has(id))) {
+          throw new Error('The diagnostic path is unavailable in this version')
+        }
+        screen = { kind: 'console', symptom, nodeId: diagnosis.node, trail: diagnosis.trail }
+      }
+      coll.reset()
+      coll.sample()
+      syncPauseButton()
+    } catch (error) {
+      root!.replaceChildren()
+      showIncidentError(error instanceof Error ? error.message : 'Incident reconstruction failed', root!)
+      return
+    }
+  } else {
+    stage('steady-state')
+    coll.reset()
+    warm(60)
+  }
+  buildRail()
+  render()
+  last = performance.now()
+  navigationReady = true
+  requestAnimationFrame(frame)
+}
+void boot()

--- a/src/observability/main.ts
+++ b/src/observability/main.ts
@@ -24,7 +24,7 @@ import { createSim } from '../sim/model'
 import { createIncidentReplay } from '../sim/replay'
 import { readIncidentHandoff } from '../core/incident-handoff'
 import type { IncidentContext } from '../core/incident-handoff'
-import { incidentCitySelection, incidentDiagnosticCaption, showIncidentError, transferIncident } from '../ui/incident-navigation'
+import { incidentCitySelection, incidentDiagnosticCaption, installIncidentCacheGuard, isSameTabIncidentClick, showIncidentError, STALE_INCIDENT_MESSAGE, transferIncident } from '../ui/incident-navigation'
 import { SCENARIOS } from '../sim/scenarios'
 import { DEFAULT_KNOBS } from '../core/types'
 import type { Knobs } from '../core/types'
@@ -262,8 +262,7 @@ function returnToCity(href = '../'): void {
 }
 root.addEventListener('click', (event) => {
   const anchor = event.target instanceof Element ? event.target.closest('a') : null
-  if (!anchor || event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey
-    || anchor.target === '_blank') return
+  if (!anchor || !isSameTabIncidentClick(event, anchor.target, anchor.hasAttribute('download'))) return
   if (anchor !== brand && !anchor.classList.contains('city-exit') && !anchor.classList.contains('citylink')) return
   event.preventDefault()
   returnToCity(anchor.href)
@@ -1121,6 +1120,7 @@ let dataT = 0
 const frameTimebase = createFrameTimebase(sim.update)
 
 function frame(now: number): void {
+  if (!navigationReady) return
   const dt = Math.min(0.1, (now - last) / 1000)
   last = now
   frameTimebase.advance(
@@ -1145,6 +1145,12 @@ function frame(now: number): void {
 }
 
 installCityEscape(() => returnToCity())
+installIncidentCacheGuard(() => {
+  navigationReady = false
+  root!.replaceChildren()
+  root!.inert = false
+  showIncidentError(STALE_INCIDENT_MESSAGE, root!)
+})
 
 window.addEventListener('keydown', (e) => {
   if (!navigationReady) return

--- a/src/observability/main.ts
+++ b/src/observability/main.ts
@@ -24,14 +24,14 @@ import { createSim } from '../sim/model'
 import { createIncidentReplay } from '../sim/replay'
 import { readIncidentHandoff } from '../core/incident-handoff'
 import type { IncidentContext } from '../core/incident-handoff'
-import { incidentCitySelection, showIncidentError, transferIncident } from '../ui/incident-navigation'
+import { incidentCitySelection, incidentDiagnosticCaption, showIncidentError, transferIncident } from '../ui/incident-navigation'
 import { SCENARIOS } from '../sim/scenarios'
 import { DEFAULT_KNOBS } from '../core/types'
 import type { Knobs } from '../core/types'
 import { NO_EA_CONTENT, TRADEMARK_NOTICE } from '../ui/legal'
 import { el, setText } from '../ui/uikit'
 import { fmtNum, reduceMotion } from '../core/util'
-import { simulationAnimationDelta } from '../core/timebase'
+import { createFrameTimebase } from '../core/timebase'
 import { cityComponentHref } from '../core/city-route'
 
 import { BY_ID, CATALOG, CATALOG_SUBSYSTEMS, VERSIONS } from './catalog'
@@ -949,10 +949,10 @@ function stagedBanner(sc: Extract<Screen, { kind: 'console' }>): HTMLElement {
   return el(
     'div',
     { class: 'staged' },
-    el('span', { class: 'staged__k', text: 'STAGED' }),
-    el('span', { class: 'staged__t', text: def ? `${def.name} — the model is running this configuration so you can read it live. Every knob on the page is still yours.` : 'free running' }),
+    el('span', { class: 'staged__k', text: linkedIncident ? 'LINKED INCIDENT' : 'STAGED' }),
+    el('span', { class: 'staged__t', text: incidentDiagnosticCaption(linkedIncident, def?.name) }),
     sc.trail.length ? backBtn : null,
-    clear,
+    linkedIncident ? null : clear,
     home,
   )
 }
@@ -1118,16 +1118,16 @@ function render(): void {
 let last = performance.now()
 let vitalT = 0
 let dataT = 0
+const frameTimebase = createFrameTimebase(sim.update)
 
 function frame(now: number): void {
   const dt = Math.min(0.1, (now - last) / 1000)
   last = now
-  const modelDt = simulationAnimationDelta(
+  frameTimebase.advance(
     dt,
     sim.state.knobs.paused,
     sim.state.knobs.timeScale,
   )
-  if (modelDt > 0) sim.update(modelDt)
   coll.sample()
   flowView?.update()
 
@@ -1147,6 +1147,7 @@ function frame(now: number): void {
 installCityEscape(() => returnToCity())
 
 window.addEventListener('keydown', (e) => {
+  if (!navigationReady) return
   if (e.key !== ' ') return
   if (
     e.target instanceof HTMLElement
@@ -1161,9 +1162,11 @@ window.addEventListener('keydown', (e) => {
  * page about statistics whose first impression is a row of zeros has already
  * lost the argument. Start it under an ordinary OLTP load instead. */
 async function boot(): Promise<void> {
+  root!.inert = true
   if (incoming.kind === 'error') {
     root!.replaceChildren()
     showIncidentError(incoming.message, root!)
+    root!.inert = false
     return
   }
   if (incoming.kind === 'ready') {
@@ -1186,6 +1189,7 @@ async function boot(): Promise<void> {
     } catch (error) {
       root!.replaceChildren()
       showIncidentError(error instanceof Error ? error.message : 'Incident reconstruction failed', root!)
+      root!.inert = false
       return
     }
   } else {
@@ -1197,6 +1201,7 @@ async function boot(): Promise<void> {
   render()
   last = performance.now()
   navigationReady = true
+  root!.inert = false
   requestAnimationFrame(frame)
 }
 void boot()

--- a/src/ui/incident-navigation.test.ts
+++ b/src/ui/incident-navigation.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from 'vitest'
+import { incidentDiagnosticCaption } from './incident-navigation'
+
+it('never claims a chosen symptom staged the linked city incident', () => {
+  expect(incidentDiagnosticCaption(true, 'Checkpoint storm')).toBe(
+    'Inspecting the linked city incident. Choosing a complaint has not changed its workload.',
+  )
+  expect(incidentDiagnosticCaption(false, 'Checkpoint storm')).toContain('Checkpoint storm')
+})

--- a/src/ui/incident-navigation.test.ts
+++ b/src/ui/incident-navigation.test.ts
@@ -1,9 +1,33 @@
-import { expect, it } from 'vitest'
-import { incidentDiagnosticCaption } from './incident-navigation'
+import { expect, it, vi } from 'vitest'
+import { incidentDiagnosticCaption, installIncidentCacheGuard, isSameTabIncidentClick } from './incident-navigation'
 
 it('never claims a chosen symptom staged the linked city incident', () => {
   expect(incidentDiagnosticCaption(true, 'Checkpoint storm')).toBe(
     'Inspecting the linked city incident. Choosing a complaint has not changed its workload.',
   )
   expect(incidentDiagnosticCaption(false, 'Checkpoint storm')).toContain('Checkpoint storm')
+})
+
+it('stops stale cache returns but leaves first navigation alone', () => {
+  const target = new EventTarget()
+  const stale = vi.fn()
+  const stop = installIncidentCacheGuard(stale, target)
+  target.dispatchEvent(Object.assign(new Event('pageshow'), { persisted: false }))
+  expect(stale).not.toHaveBeenCalled()
+  target.dispatchEvent(Object.assign(new Event('pageshow'), { persisted: true }))
+  expect(stale).toHaveBeenCalledOnce()
+  stop()
+  target.dispatchEvent(Object.assign(new Event('pageshow'), { persisted: true }))
+  expect(stale).toHaveBeenCalledOnce()
+})
+
+it('only transfers explicit same-tab primary clicks', () => {
+  const click = { button: 0, ctrlKey: false, metaKey: false, altKey: false, shiftKey: false }
+  expect(isSameTabIncidentClick(click, '', false)).toBe(true)
+  for (const key of ['ctrlKey', 'metaKey', 'altKey', 'shiftKey'] as const) {
+    expect(isSameTabIncidentClick({ ...click, [key]: true }, '', false)).toBe(false)
+  }
+  expect(isSameTabIncidentClick({ ...click, button: 1 }, '', false)).toBe(false)
+  expect(isSameTabIncidentClick(click, '_blank', false)).toBe(false)
+  expect(isSameTabIncidentClick(click, '', true)).toBe(false)
 })

--- a/src/ui/incident-navigation.ts
+++ b/src/ui/incident-navigation.ts
@@ -1,0 +1,55 @@
+import { cityComponentId } from '../core/city-route'
+import { writeIncidentHandoff } from '../core/incident-handoff'
+import type { IncidentContext, IncidentDestination } from '../core/incident-handoff'
+import type { Bus } from '../core/types'
+import type { IncidentReplay } from '../sim/replay'
+
+export function showIncidentError(message: string, parent: HTMLElement = document.body): HTMLElement {
+  const panel = document.createElement('section')
+  panel.setAttribute('role', 'alert')
+  panel.className = 'incident-navigation-message'
+  panel.style.cssText = 'padding:16px;background:#182330;color:#fff;border:2px solid #e6af57;position:relative;z-index:10000;font:16px/1.5 system-ui;max-width:760px'
+  panel.textContent = `Incident not transferred. ${message}. No replacement incident has been started.`
+  parent.prepend(panel)
+  return panel
+}
+
+export function transferIncident(options: {
+  replay: IncidentReplay; destination: IncidentDestination; context: IncidentContext; href: string
+}): boolean {
+  try {
+    const target = new URL(options.href, location.href)
+    if (target.origin !== location.origin) throw new Error('Incident navigation must stay on this site')
+    writeIncidentHandoff(() => sessionStorage, options.replay, options.destination, options.context)
+    target.hash = 'incident'
+    location.assign(target.href)
+    return true
+  } catch (error) {
+    showIncidentError(error instanceof Error ? error.message : 'Tab storage is unavailable')
+    return false
+  }
+}
+
+/** Same-tab navigation only: browser new-tab commands must not imply continuity. */
+export function installCityIncidentNavigation(options: {
+  replay: IncidentReplay; bus: Bus; context?: IncidentContext
+}): () => void {
+  const context: IncidentContext = { ...options.context }
+  const off = options.bus.on('select', ({ id }) => { context.selected = id ?? undefined })
+  const click = (event: MouseEvent): void => {
+    const anchor = event.target instanceof Element ? event.target.closest('a') : null
+    if (!anchor || event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey
+      || anchor.target === '_blank' || anchor.hasAttribute('download')) return
+    const target = new URL(anchor.href, location.href)
+    if (target.origin !== location.origin || !/\/observability\/?$/.test(target.pathname)
+      || target.searchParams.get('view') === 'flow') return
+    event.preventDefault()
+    transferIncident({ replay: options.replay, destination: 'diagnose', context, href: target.href })
+  }
+  document.addEventListener('click', click, true)
+  return () => { off(); document.removeEventListener('click', click, true) }
+}
+
+export function incidentCitySelection(href: string, fallback: string | undefined): string | undefined {
+  return cityComponentId(new URL(href, location.href).hash) ?? fallback
+}

--- a/src/ui/incident-navigation.ts
+++ b/src/ui/incident-navigation.ts
@@ -4,6 +4,24 @@ import type { IncidentContext, IncidentDestination } from '../core/incident-hand
 import type { Bus } from '../core/types'
 import type { IncidentReplay } from '../sim/replay'
 
+export const STALE_INCIDENT_MESSAGE = 'Browser Back or Forward restored an older page, not the latest incident. Its model has been stopped. Use the linked navigation buttons from the current incident, or explicitly open a new city'
+
+export function installIncidentCacheGuard(onStale: () => void, target: EventTarget = window): () => void {
+  const restore = (event: Event): void => {
+    if ((event as PageTransitionEvent).persisted) onStale()
+  }
+  target.addEventListener('pageshow', restore)
+  return () => target.removeEventListener('pageshow', restore)
+}
+
+export function isSameTabIncidentClick(
+  event: Pick<MouseEvent, 'button' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'altKey'>,
+  target: string, download: boolean,
+): boolean {
+  return event.button === 0 && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey
+    && (target === '' || target === '_self') && !download
+}
+
 export function incidentDiagnosticCaption(linked: boolean, stagedName?: string): string {
   if (linked) return 'Inspecting the linked city incident. Choosing a complaint has not changed its workload.'
   return stagedName ? `${stagedName} — the model is running this configuration so you can read it live. Every knob on the page is still yours.` : 'free running'
@@ -48,8 +66,7 @@ export function installCityIncidentNavigation(options: {
   const off = options.bus.on('select', ({ id }) => { context.selected = id ?? undefined })
   const click = (event: MouseEvent): void => {
     const anchor = event.target instanceof Element ? event.target.closest('a') : null
-    if (!anchor || event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey
-      || anchor.target === '_blank' || anchor.hasAttribute('download')) return
+    if (!anchor || !isSameTabIncidentClick(event, anchor.target, anchor.hasAttribute('download'))) return
     const target = new URL(anchor.href, location.href)
     if (target.origin !== location.origin || !/\/observability\/?$/.test(target.pathname)
       || target.searchParams.get('view') === 'flow') return

--- a/src/ui/incident-navigation.ts
+++ b/src/ui/incident-navigation.ts
@@ -4,12 +4,22 @@ import type { IncidentContext, IncidentDestination } from '../core/incident-hand
 import type { Bus } from '../core/types'
 import type { IncidentReplay } from '../sim/replay'
 
+export function incidentDiagnosticCaption(linked: boolean, stagedName?: string): string {
+  if (linked) return 'Inspecting the linked city incident. Choosing a complaint has not changed its workload.'
+  return stagedName ? `${stagedName} — the model is running this configuration so you can read it live. Every knob on the page is still yours.` : 'free running'
+}
+
 export function showIncidentError(message: string, parent: HTMLElement = document.body): HTMLElement {
   const panel = document.createElement('section')
   panel.setAttribute('role', 'alert')
   panel.className = 'incident-navigation-message'
   panel.style.cssText = 'padding:16px;background:#182330;color:#fff;border:2px solid #e6af57;position:relative;z-index:10000;font:16px/1.5 system-ui;max-width:760px'
   panel.textContent = `Incident not transferred. ${message}. No replacement incident has been started.`
+  const restart = document.createElement('a')
+  restart.href = /\/observability\/?$/.test(location.pathname) ? '../' : './'
+  restart.textContent = 'Open a new city instead (discard this transfer)'
+  restart.style.cssText = 'display:block;color:#b9e3ff;margin-top:12px'
+  panel.append(restart)
   parent.prepend(panel)
   return panel
 }

--- a/test/corrections.browser.test.ts
+++ b/test/corrections.browser.test.ts
@@ -222,11 +222,13 @@ describe('PostgreSQL correction reports', () => {
         }
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
       })()`,
       prepare: `(() => {
         const { sim, bus } = window.PGSIMCITY
         document.querySelector('.control-center').hidden = false
         document.querySelector('#hud-latency-panel').hidden = false
+        document.querySelector('.pg-replay').hidden = false
         sim.setKnob('recoveryTargetAge', 40)
         sim.setKnob('walGDownloadConcurrency', 4)
         Object.assign(sim.state.disasterRecovery.drill, {


### PR DESCRIPTION
## Scope

Relates to #15. Stacked on #26 (codex/incident-replay).

- Wire City bootstrap to restore the validated seed, action history and clock before model animation starts; restore selected objects after the world is ready.
- Transfer bounded, versioned records through same-tab sessionStorage using only a fixed URL marker. Reject malformed, expired, unsupported and consumed transfers visibly.
- Diagnose inspects linked incidents without staging another workload and retains the diagnostic path on explicit return to City. Diagnostic counter windows start on arrival; PGlite remains separate, opt-in evidence.
- Preserve same-tab navigation only. Modified clicks and new-tab commands remain separate navigation. Browser-cache returns stop the stale model and show explicit recovery instead of resuming an older incident as current.

## Validation

17 targeted tests, TypeScript checking and production build pass locally. Tests include complete model-state round trip, nondefault seed, bounded inputs, version and expiry failures, one-use reload behavior, diagnostic history, modified clicks and cached-page guard behavior.

Pending gates: full CI on this exact source branch; browser City/Diagnose round trip with action, clock, object and path checks; reload/cache-return and mobile-disclosure checks; substantive independent review. integration_qa coordinates browser and full-suite verification under the two-browser cap.

The inherited high-severity nanoid advisory remains a centrally tracked release gate; this PR adds no dependencies. Draft only: no merge or release is requested until all gates report.