### PR TITLE
fix: retain profiles when inspection fails

### DIFF
--- a/test/cdp-profile-unavailable.test.ts
+++ b/test/cdp-profile-unavailable.test.ts
@@ -1,0 +1,66 @@
+import { existsSync, mkdtempSync, rmSync, utimesSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it, vi } from 'vitest'
+import { acquireCdpProfile, reapStaleProfiles } from '../tools/cdp-profile.mjs'
+
+const processTable = vi.hoisted(() => ({ unavailable: false }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...fs,
+    readdirSync: (...args: Parameters<typeof fs.readdirSync>) => {
+      if (processTable.unavailable && args[0] === '/proc') throw new Error('unavailable')
+      return fs.readdirSync(...args)
+    },
+  }
+})
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const child = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...child,
+    execFileSync: (...args: Parameters<typeof child.execFileSync>) => {
+      if (processTable.unavailable && args[0] === 'ps') throw new Error('unavailable')
+      return child.execFileSync(...args)
+    },
+  }
+})
+
+const roots: string[] = []
+afterEach(() => {
+  processTable.unavailable = false
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+it('retains an owned profile when neither process source is readable', () => {
+  const root = mkdtempSync(join(tmpdir(), 'pgsimcity-profile-unknown-'))
+  roots.push(root)
+  const profile = acquireCdpProfile({ root, reap: false })
+
+  processTable.unavailable = true
+  expect(profile.cleanup()).toBe(false)
+  expect(existsSync(profile.path)).toBe(true)
+
+  processTable.unavailable = false
+  expect(profile.cleanup()).toBe(true)
+  expect(existsSync(profile.path)).toBe(false)
+})
+
+it('does not reap an old profile on unknown usage, even with a dead owner', () => {
+  const root = mkdtempSync(join(tmpdir(), 'pgsimcity-profile-unknown-'))
+  roots.push(root)
+  const profile = acquireCdpProfile({ root, reap: false })
+  const now = Date.now()
+  const old = new Date(now - 11 * 60 * 1000)
+  utimesSync(profile.path, old, old)
+
+  processTable.unavailable = true
+  expect(reapStaleProfiles({ root, now, ownerIsAlive: () => false })).toEqual([])
+  expect(existsSync(profile.path)).toBe(true)
+
+  processTable.unavailable = false
+  expect(reapStaleProfiles({ root, now, ownerIsAlive: () => false })).toEqual([profile.path])
+  expect(existsSync(profile.path)).toBe(false)
+})

--- a/tools/cdp-profile.mjs
+++ b/tools/cdp-profile.mjs
@@ -69,7 +69,7 @@ function readCommandLines() {
 
 export function profileIsInUse(profilePath) {
   const commandLines = readCommandLines()
-  if (!commandLines) return false
+  if (!commandLines) return true
 
   const profileArgument = `--user-data-dir=${profilePath}`
   // Chrome flattens its command line into argv[0] on some hosts.


### PR DESCRIPTION
## Fix

Closes #37. Release dependency for #36.

Treat unreadable process inspection as potentially in-use, retaining managed Chrome profiles instead of deleting them. This is a conservative failure-path change; readable process tables keep the existing behavior.

## Red/green evidence

- Added two deterministic filesystem-level tests: owned cleanup and stale cleanup with a dead recorded owner, with both `/proc` and `ps` unavailable.
- RED on main: both failed because the directories were deleted.
- GREEN: all 10 profile/cleanup tests passed; both tests also verify cleanup resumes after process inspection recovers.
- Typecheck passed. Full non-browser suite/build are running, exact-head CI and substantive REV/GPT re-review still required.

No production simulation or rendering behavior changes. Review finding came from an independent release-wide GPT audit, separate from implementation.
