### PR TITLE
fix: scope replica identity guidance

### DIFF
--- a/src/ui/docs-storage.ts
+++ b/src/ui/docs-storage.ts
@@ -1154,7 +1154,7 @@ export const DOCS_STORAGE: ComponentDoc[] = [
     refs: {
       docs: [
         manual('logicaldecoding.html', 'Chapter 47. Logical Decoding'),
-        manual('logical-replication-publication.html#LOGICAL-REPLICATION-REPLICA-IDENTITY', '29.1.1 Replica Identity'),
+        manual('logical-replication-publication.html#LOGICAL-REPLICATION-PUBLICATION-REPLICA-IDENTITY', '29.1.1 Replica Identity'),
         manual('sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY', 'ALTER TABLE — REPLICA IDENTITY'),
       ],
       source: [

--- a/src/ui/docs-storage.ts
+++ b/src/ui/docs-storage.ts
@@ -1109,7 +1109,11 @@ export const DOCS_STORAGE: ComponentDoc[] = [
       },
       {
         heading: 'What it needs from you',
-        body: 'It requires `wal_level = logical`, which is a restart, and which makes WAL bigger because extra information has to be logged for decoding to be possible at all. It also requires a **replica identity** on any table you UPDATE or DELETE: by default that is the primary key, and a table with no primary key will error out unless you set `REPLICA IDENTITY FULL` (which logs the entire old row into WAL — correct, and expensive). Finally, it needs a logical slot, with all the disk-filling risk that carries.',
+        body: 'It requires `wal_level = logical`, which is a restart, and which makes WAL bigger because extra information has to be logged for decoding to be possible at all. Finally, it needs a logical slot, with all the disk-filling risk that carries.',
+      },
+      {
+        heading: 'Replica identity for built-in replication',
+        body: 'For built-in logical replication, a table in a publication that publishes `UPDATE` or `DELETE` needs a **replica identity** so the subscriber can identify the affected row. A primary key is the default; an eligible unique index can instead be selected with `REPLICA IDENTITY USING INDEX`. `REPLICA IDENTITY FULL` is a fallback when no suitable key is available: it records the old row and can make subscriber lookups expensive. Without a usable identity, the published UPDATE or DELETE fails on the publisher. `INSERT` does not require replica identity. This publication rule is not a primary-key requirement for logical decoding itself.',
       },
       {
         heading: 'The reorder buffer',
@@ -1148,7 +1152,11 @@ export const DOCS_STORAGE: ComponentDoc[] = [
       'src/backend/replication/slot.c',
     ],
     refs: {
-      docs: [manual('logicaldecoding.html', 'Chapter 47. Logical Decoding')],
+      docs: [
+        manual('logicaldecoding.html', 'Chapter 47. Logical Decoding'),
+        manual('logical-replication-publication.html#LOGICAL-REPLICATION-REPLICA-IDENTITY', '29.1.1 Replica Identity'),
+        manual('sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY', 'ALTER TABLE — REPLICA IDENTITY'),
+      ],
       source: [
         srcFile('src/backend/replication/logical/decode.c', 'LogicalDecodingProcessRecord'),
         srcFile('src/backend/replication/logical/reorderbuffer.c', 'ReorderBufferProcessTXN, ReorderBufferCommit'),

--- a/test/replica-identity-copy.test.ts
+++ b/test/replica-identity-copy.test.ts
@@ -1,6 +1,12 @@
 import { expect, it } from 'vitest'
 import { DOCS_STORAGE } from '../src/ui/docs-storage'
 
+it('links directly to the publication replica-identity section', () => {
+  const decoder = DOCS_STORAGE.find((entry) => entry.id === 'logical.decoder')!
+  expect(decoder.refs?.docs?.find((ref) => ref.label === '29.1.1 Replica Identity')?.url)
+    .toBe('https://www.postgresql.org/docs/18/logical-replication-publication.html#LOGICAL-REPLICATION-PUBLICATION-REPLICA-IDENTITY')
+})
+
 const decoderCopy = DOCS_STORAGE.find((entry) => entry.id === 'logical.decoder')!
   .sections.map((section) => section.body).join('\n')
 

--- a/test/replica-identity-copy.test.ts
+++ b/test/replica-identity-copy.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from 'vitest'
+import { DOCS_STORAGE } from '../src/ui/docs-storage'
+
+const decoderCopy = DOCS_STORAGE.find((entry) => entry.id === 'logical.decoder')!
+  .sections.map((section) => section.body).join('\n')
+
+it('scopes the identity requirement to published update/delete operations', () => {
+  expect(decoderCopy).not.toMatch(/a table with no primary key will error out unless/)
+  expect(decoderCopy).toMatch(/publication[^.]*`UPDATE`[^.]*`DELETE`/)
+  expect(decoderCopy).toMatch(/`INSERT`[^.]*does not require/)
+})
+
+it('offers an eligible identity index before the full-row fallback', () => {
+  expect(decoderCopy).toContain('eligible unique index')
+  expect(decoderCopy).toContain('REPLICA IDENTITY USING INDEX')
+  expect(decoderCopy).toMatch(/`REPLICA IDENTITY FULL`[^.]*fallback/)
+})


### PR DESCRIPTION
## Correction

Closes #40; release blocker for #36 found by independent Opus 5 fidelity review.

Separate logical decoding from the replica-identity requirement for a publication that replicates UPDATE/DELETE. Explain an eligible unique index, FULL as fallback, and INSERT without identity. Link the publication and ALTER TABLE documentation beside the explanation.

## Verification

- RED: both public-copy regression tests fail on main.
- GREEN: 28 focused tests passed; typecheck and production build passed. Full non-browser suite running; exact-head CI will validate all suites.
- Actual PostgreSQL 18.6 in an isolated throwaway container confirmed all five cases: unpublished UPDATE decoded successfully without a primary key; published UPDATE failed without identity; USING INDEX allowed UPDATE without a primary key; published INSERT succeeded with identity NOTHING; FULL allowed UPDATE as a fallback. No existing database was reused and the container had no network access.
- Sources: [Replica Identity](https://www.postgresql.org/docs/18/logical-replication-publication.html#LOGICAL-REPLICATION-REPLICA-IDENTITY), [ALTER TABLE](https://www.postgresql.org/docs/18/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY).

No simulation behavior or renderer changes. Independent re-review remains required; this patch alone does not establish release readiness.
