### PR TITLE
docs: bound oracle verification coverage

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -72,7 +72,7 @@ These are hard constraints in the code, not aspirations.
    the registered `wait_event_type`/`wait_event` pairs, and the `pg_stat_io`
    `object` and `context` values this page emits. The vacuum phase strings
    and the six non-`pg_stat_*` catalog entries are manual-checked only.
-   See [oracle coverage](../ORACLE-AUDIT.md) for the check boundaries. Where a
+   Where a
    name changed between releases the change is recorded and shown. The
    capitalisation counts: PostgreSQL 17 began generating the wait event list
    from a table and normalised it on the way through, so the WAL flush wait is

--- a/observability/README.md
+++ b/observability/README.md
@@ -66,8 +66,13 @@ These are hard constraints in the code, not aspirations.
 1. **Names are real.** Every view, function, column and enum value — every
    `wait_event_type`/`wait_event` pair, every vacuum `phase` string, every
    `pg_stat_io` `object` and `context` value — was checked against
-    the [PostgreSQL 18 manual](https://www.postgresql.org/docs/18/) and verified
-    against PostgreSQL 18.6. Where a
+   the [PostgreSQL 18 manual](https://www.postgresql.org/docs/18/).
+   A registered subset is additionally machine-checked against a live
+   PostgreSQL 18.6 server by the oracle: the `pg_stat_*` view column shapes,
+   the registered `wait_event_type`/`wait_event` pairs, and the `pg_stat_io`
+   `object` and `context` values this page emits. The vacuum phase strings
+   and the six non-`pg_stat_*` catalog entries are manual-checked only.
+   See [oracle coverage](../ORACLE-AUDIT.md) for the check boundaries. Where a
    name changed between releases the change is recorded and shown. The
    capitalisation counts: PostgreSQL 17 began generating the wait event list
    from a table and normalised it on the way through, so the WAL flush wait is

--- a/test/oracle-coverage-copy.test.ts
+++ b/test/oracle-coverage-copy.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs'
+import { expect, it } from 'vitest'
+
+it('distinguishes manual name review from registered live-server checks', () => {
+  const readme = readFileSync(new URL('../observability/README.md', import.meta.url), 'utf8')
+  const names = readme.split('1. **Names are real.**')[1].split('2. **')[0]
+  expect(names).toContain('A registered subset')
+  expect(names).toMatch(/vacuum phase strings[^.]*manual-checked only/)
+  expect(names).not.toMatch(/every[\s\S]*and verified\s+against PostgreSQL/)
+})

--- a/test/oracle-coverage-copy.test.ts
+++ b/test/oracle-coverage-copy.test.ts
@@ -5,6 +5,7 @@ it('distinguishes manual name review from registered live-server checks', () => 
   const readme = readFileSync(new URL('../observability/README.md', import.meta.url), 'utf8')
   const names = readme.split('1. **Names are real.**')[1].split('2. **')[0]
   expect(names).toContain('A registered subset')
+  expect(names).not.toContain('../ORACLE-AUDIT.md')
   expect(names).toMatch(/vacuum phase strings[^.]*manual-checked only/)
   expect(names).not.toMatch(/every[\s\S]*and verified\s+against PostgreSQL/)
 })


### PR DESCRIPTION
## Scope

Follow-up to the independent Opus REV finding: distinguish manual PostgreSQL name review from the registered subset checked by the live-server oracle. No catalog names or oracle assertions change. Stacked on the maintenance candidate for isolated review.

## Validation

- Regression failed before the prose correction.
- All 1,016 non-browser tests passed; typecheck and build passed, exit 0.
- Source/editorial review checked the stated boundaries against tools/pg-oracle.mjs and the registered claims.
- Hosted CI and independent exact-head re-review remain required before integration.
